### PR TITLE
feat(tools): ingest and analysis tools with connection safety

### DIFF
--- a/src/pcap_agent/tools/__init__.py
+++ b/src/pcap_agent/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Agent tools for PCAP analysis."""

--- a/src/pcap_agent/tools/_state.py
+++ b/src/pcap_agent/tools/_state.py
@@ -1,4 +1,8 @@
-"""Module-level DuckDB connection shared across all tools."""
+"""Module-level DuckDB connection shared across all tools.
+
+These tools assume single-threaded, single-PCAP-per-session use (CLI agent).
+No locking is applied; concurrent access from multiple threads is not supported.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +21,10 @@ def set_connection(conn: duckdb.DuckDBPyConnection, db_path: str) -> None:
 def require_connection() -> duckdb.DuckDBPyConnection:
     if _conn is None:
         raise RuntimeError("No PCAP ingested yet. Call ingest_pcap() first.")
+    return _conn
+
+
+def get_connection() -> duckdb.DuckDBPyConnection | None:
     return _conn
 
 

--- a/src/pcap_agent/tools/_state.py
+++ b/src/pcap_agent/tools/_state.py
@@ -1,0 +1,33 @@
+"""Module-level DuckDB connection shared across all tools."""
+
+from __future__ import annotations
+
+import duckdb
+
+_conn: duckdb.DuckDBPyConnection | None = None
+_db_path: str | None = None
+
+
+def set_connection(conn: duckdb.DuckDBPyConnection, db_path: str) -> None:
+    global _conn, _db_path
+    _conn = conn
+    _db_path = db_path
+
+
+def require_connection() -> duckdb.DuckDBPyConnection:
+    if _conn is None:
+        raise RuntimeError("No PCAP ingested yet. Call ingest_pcap() first.")
+    return _conn
+
+
+def get_db_path() -> str | None:
+    return _db_path
+
+
+def reset(
+    conn: duckdb.DuckDBPyConnection | None = None,
+    db_path: str | None = None,
+) -> None:
+    global _conn, _db_path
+    _conn = conn
+    _db_path = db_path

--- a/src/pcap_agent/tools/analysis.py
+++ b/src/pcap_agent/tools/analysis.py
@@ -1,0 +1,37 @@
+"""Read-only analysis tools: protocol breakdown and top talkers."""
+
+from pcap_agent.tools import _state
+
+_PROTO_MAP = {1: "ICMP", 6: "TCP", 17: "UDP"}
+
+
+def get_protocol_breakdown() -> list[dict]:
+    """Return per-protocol packet counts sorted descending by count."""
+    conn = _state.require_connection()
+    total = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+    rows = conn.execute(
+        "SELECT protocol, COUNT(*) AS count "
+        "FROM packets "
+        "GROUP BY protocol "
+        "ORDER BY count DESC"
+    ).fetchall()
+    result = []
+    for proto_num, count in rows:
+        name = _PROTO_MAP.get(int(proto_num), f"proto_{proto_num}")
+        pct = round(count / total * 100, 1) if total else 0.0
+        result.append({"protocol": name, "count": count, "pct": pct})
+    return result
+
+
+def get_top_talkers(n: int = 10) -> list[dict]:
+    """Return top-N source IPs ranked by packet count."""
+    conn = _state.require_connection()
+    rows = conn.execute(
+        "SELECT src_ip, COUNT(*) AS packet_count "
+        "FROM packets "
+        "GROUP BY src_ip "
+        "ORDER BY packet_count DESC "
+        "LIMIT ?",
+        [n],
+    ).fetchall()
+    return [{"src_ip": r[0], "packet_count": r[1]} for r in rows]

--- a/src/pcap_agent/tools/analysis.py
+++ b/src/pcap_agent/tools/analysis.py
@@ -17,7 +17,10 @@ def get_protocol_breakdown() -> list[dict]:
     ).fetchall()
     result = []
     for proto_num, count in rows:
-        name = _PROTO_MAP.get(int(proto_num), f"proto_{proto_num}")
+        if proto_num is not None:
+            name = _PROTO_MAP.get(int(proto_num), f"proto_{proto_num}")
+        else:
+            name = "unknown"
         pct = round(count / total * 100, 1) if total else 0.0
         result.append({"protocol": name, "count": count, "pct": pct})
     return result
@@ -25,6 +28,8 @@ def get_protocol_breakdown() -> list[dict]:
 
 def get_top_talkers(n: int = 10) -> list[dict]:
     """Return top-N source IPs ranked by packet count."""
+    if n <= 0:
+        return []
     conn = _state.require_connection()
     rows = conn.execute(
         "SELECT src_ip, COUNT(*) AS packet_count "

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -34,8 +34,12 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     else:
         old_conn = _state.get_connection()
         conn = duckdb.connect(db_path)
-        db.create_schema(conn)
-        _state.set_connection(conn, db_path)
+        try:
+            db.create_schema(conn)
+            _state.set_connection(conn, db_path)
+        except Exception:
+            conn.close()
+            raise
         if old_conn is not None:
             old_conn.close()
 

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -26,9 +26,15 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     Path(effective_db_dir).mkdir(parents=True, exist_ok=True)
     db_path = str(Path(effective_db_dir) / f"{sha256[:12]}.duckdb")
 
-    conn = duckdb.connect(db_path)
-    db.create_schema(conn)
-    _state.set_connection(conn, db_path)
+    # Reuse the existing connection when the target file is already open to
+    # avoid leaking the previous handle and conflicting with DuckDB's
+    # single-writer constraint.
+    if _state.get_db_path() == db_path and _state.get_connection() is not None:
+        conn = _state.require_connection()
+    else:
+        conn = duckdb.connect(db_path)
+        db.create_schema(conn)
+        _state.set_connection(conn, db_path)
 
     if db.get_cached(conn, sha256) is not None:
         return _summary(conn, sha256, db_path, cached=True)

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -32,9 +32,12 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     if _state.get_db_path() == db_path and _state.get_connection() is not None:
         conn = _state.require_connection()
     else:
+        old_conn = _state.get_connection()
         conn = duckdb.connect(db_path)
         db.create_schema(conn)
         _state.set_connection(conn, db_path)
+        if old_conn is not None:
+            old_conn.close()
 
     if db.get_cached(conn, sha256) is not None:
         return _summary(conn, sha256, db_path, cached=True)

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -1,0 +1,78 @@
+"""Ingest tool: parse and persist a PCAP file, auto-run analysis."""
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+from pcap_agent import db, parser
+from pcap_agent.config import config
+from pcap_agent.tools import _state
+from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
+
+
+def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
+    """Ingest a PCAP file into DuckDB and return a summary dict.
+
+    Returns cached results (cached=True) without re-parsing if the file was
+    already ingested (same SHA256). Otherwise parses, persists, and auto-runs
+    protocol breakdown and top-talker analysis.
+    """
+    pcap_path = Path(path)
+    sha256 = _sha256(pcap_path)
+
+    effective_db_dir = db_dir or config.pcap_agent_db_dir
+    Path(effective_db_dir).mkdir(parents=True, exist_ok=True)
+    db_path = str(Path(effective_db_dir) / f"{sha256[:12]}.duckdb")
+
+    conn = duckdb.connect(db_path)
+    db.create_schema(conn)
+    _state.set_connection(conn, db_path)
+
+    if db.get_cached(conn, sha256) is not None:
+        return _summary(conn, sha256, db_path, cached=True)
+
+    frames = parser.parse(pcap_path)
+    conn.begin()
+    try:
+        db.ingest(conn, frames, begin_transaction=False)
+        db.set_cached(conn, sha256, str(pcap_path))
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return _summary(conn, sha256, db_path, cached=False)
+
+
+def _summary(
+    conn: duckdb.DuckDBPyConnection,
+    sha256: str,
+    db_path: str,
+    *,
+    cached: bool,
+) -> dict[str, Any]:
+    n_packets = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+    row = conn.execute(
+        "SELECT MIN(timestamp), MAX(timestamp) FROM packets"
+    ).fetchone()
+    time_start, time_end = (row[0], row[1]) if row else (None, None)
+    return {
+        "cached": cached,
+        "sha256": sha256,
+        "n_packets": n_packets,
+        "time_start": time_start,
+        "time_end": time_end,
+        "protocol_counts": get_protocol_breakdown(),
+        "top_talkers": get_top_talkers(10),
+        "db_path": db_path,
+    }
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from constants import (
 from scapy.all import ICMP, IP, TCP, UDP, Raw, wrpcap  # type: ignore[import-untyped]
 
 from pcap_agent import db, parser
+from pcap_agent.tools import _state
 from pcap_agent.tools.ingest import ingest_pcap
 
 
@@ -133,3 +134,13 @@ def ingested_db(synthetic_pcap, tmp_path_factory):
     """Ingest the synthetic PCAP into a temp DuckDB once per session."""
     db_dir = str(tmp_path_factory.mktemp("dbs"))
     return ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+
+
+@pytest.fixture(scope="session")
+def ingested_conn(ingested_db):  # noqa: ARG001
+    """Return the DuckDB connection established by ingested_db.
+
+    Declaring ingested_db as a dependency ensures the session fixture has run
+    and _state._conn is set before any test uses this fixture.
+    """
+    return _state.require_connection()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from constants import (
 from scapy.all import ICMP, IP, TCP, UDP, Raw, wrpcap  # type: ignore[import-untyped]
 
 from pcap_agent import db, parser
+from pcap_agent.tools.ingest import ingest_pcap
 
 
 def pytest_configure(config):  # noqa: ARG001
@@ -125,3 +126,10 @@ def duckdb_conn():
     db.create_schema(conn)
     yield conn
     conn.close()
+
+
+@pytest.fixture(scope="session")
+def ingested_db(synthetic_pcap, tmp_path_factory):
+    """Ingest the synthetic PCAP into a temp DuckDB once per session."""
+    db_dir = str(tmp_path_factory.mktemp("dbs"))
+    return ingest_pcap(str(synthetic_pcap), db_dir=db_dir)

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -1,0 +1,76 @@
+"""Integration tests for tools.analysis: get_top_talkers, get_protocol_breakdown."""
+
+from constants import (
+    ICMP_PACKET_COUNT,
+    TCP_TOTAL,
+    TOTAL_IP,
+    UDP_PACKET_COUNT,
+    UDP_TOP_TALKER_IP,
+    UDP_TOTAL,
+)
+
+from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
+
+
+class TestGetTopTalkers:
+    def test_top_talker_is_heavy_udp_sender(self, ingested_db):
+        talkers = get_top_talkers(1)
+        assert talkers[0]["src_ip"] == UDP_TOP_TALKER_IP
+
+    def test_top_talker_packet_count(self, ingested_db):
+        talkers = get_top_talkers(1)
+        assert talkers[0]["packet_count"] == UDP_PACKET_COUNT
+
+    def test_returns_n_results(self, ingested_db):
+        talkers = get_top_talkers(3)
+        assert len(talkers) == 3
+
+    def test_results_sorted_descending(self, ingested_db):
+        talkers = get_top_talkers(10)
+        counts = [t["packet_count"] for t in talkers]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_result_keys(self, ingested_db):
+        talkers = get_top_talkers(1)
+        assert set(talkers[0].keys()) == {"src_ip", "packet_count"}
+
+
+class TestGetProtocolBreakdown:
+    def test_returns_list(self, ingested_db):
+        result = get_protocol_breakdown()
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_tcp_count(self, ingested_db):
+        result = get_protocol_breakdown()
+        tcp = next(r for r in result if r["protocol"] == "TCP")
+        assert tcp["count"] == TCP_TOTAL
+
+    def test_udp_count(self, ingested_db):
+        result = get_protocol_breakdown()
+        udp = next(r for r in result if r["protocol"] == "UDP")
+        assert udp["count"] == UDP_TOTAL
+
+    def test_icmp_count(self, ingested_db):
+        result = get_protocol_breakdown()
+        icmp = next(r for r in result if r["protocol"] == "ICMP")
+        assert icmp["count"] == ICMP_PACKET_COUNT
+
+    def test_total_equals_all_packets(self, ingested_db):
+        result = get_protocol_breakdown()
+        total = sum(r["count"] for r in result)
+        assert total == TOTAL_IP
+
+    def test_sorted_descending(self, ingested_db):
+        result = get_protocol_breakdown()
+        counts = [r["count"] for r in result]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_result_keys(self, ingested_db):
+        result = get_protocol_breakdown()
+        assert set(result[0].keys()) == {"protocol", "count", "pct"}
+
+    def test_pct_sums_to_100(self, ingested_db):
+        result = get_protocol_breakdown()
+        total_pct = sum(r["pct"] for r in result)
+        assert abs(total_pct - 100.0) < 0.2

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -8,38 +8,41 @@ from constants import (
     UDP_TOTAL,
 )
 
-from pcap_agent.tools import _state
+from pcap_agent.tools import _state  # noqa: F401 — used by _restore_state
 from pcap_agent.tools.ingest import ingest_pcap
 
 
 @pytest.fixture
 def _restore_state():
     """Restore _state after a test that temporarily changes the connection."""
-    saved_conn = _state._conn
-    saved_path = _state._db_path
+    saved_conn = _state.get_connection()
+    saved_path = _state.get_db_path()
     yield
+    new_conn = _state.get_connection()
     _state.reset(saved_conn, saved_path)
+    if new_conn is not None and new_conn is not saved_conn:
+        new_conn.close()
 
 
 class TestIngestPcap:
-    def test_packets_table_populated(self, ingested_db):
-        conn = _state.require_connection()
-        count = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+    def test_packets_table_populated(self, ingested_conn):
+        count = ingested_conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
         assert count == TOTAL_IP
 
-    def test_tcp_segments_table_populated(self, ingested_db):
-        conn = _state.require_connection()
-        count = conn.execute("SELECT COUNT(*) FROM tcp_segments").fetchone()[0]
+    def test_tcp_segments_table_populated(self, ingested_conn):
+        count = ingested_conn.execute("SELECT COUNT(*) FROM tcp_segments").fetchone()[0]
         assert count == TCP_TOTAL
 
-    def test_udp_datagrams_table_populated(self, ingested_db):
-        conn = _state.require_connection()
-        count = conn.execute("SELECT COUNT(*) FROM udp_datagrams").fetchone()[0]
+    def test_udp_datagrams_table_populated(self, ingested_conn):
+        count = ingested_conn.execute(
+            "SELECT COUNT(*) FROM udp_datagrams"
+        ).fetchone()[0]
         assert count == UDP_TOTAL
 
-    def test_icmp_messages_table_populated(self, ingested_db):
-        conn = _state.require_connection()
-        count = conn.execute("SELECT COUNT(*) FROM icmp_messages").fetchone()[0]
+    def test_icmp_messages_table_populated(self, ingested_conn):
+        count = ingested_conn.execute(
+            "SELECT COUNT(*) FROM icmp_messages"
+        ).fetchone()[0]
         assert count == ICMP_PACKET_COUNT
 
     def test_summary_n_packets(self, ingested_db):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,99 @@
+"""Integration tests for tools.ingest.ingest_pcap."""
+
+import pytest
+from constants import (
+    ICMP_PACKET_COUNT,
+    TCP_TOTAL,
+    TOTAL_IP,
+    UDP_TOTAL,
+)
+
+from pcap_agent.tools import _state
+from pcap_agent.tools.ingest import ingest_pcap
+
+
+@pytest.fixture
+def _restore_state():
+    """Restore _state after a test that temporarily changes the connection."""
+    saved_conn = _state._conn
+    saved_path = _state._db_path
+    yield
+    _state.reset(saved_conn, saved_path)
+
+
+class TestIngestPcap:
+    def test_packets_table_populated(self, ingested_db):
+        conn = _state.require_connection()
+        count = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+        assert count == TOTAL_IP
+
+    def test_tcp_segments_table_populated(self, ingested_db):
+        conn = _state.require_connection()
+        count = conn.execute("SELECT COUNT(*) FROM tcp_segments").fetchone()[0]
+        assert count == TCP_TOTAL
+
+    def test_udp_datagrams_table_populated(self, ingested_db):
+        conn = _state.require_connection()
+        count = conn.execute("SELECT COUNT(*) FROM udp_datagrams").fetchone()[0]
+        assert count == UDP_TOTAL
+
+    def test_icmp_messages_table_populated(self, ingested_db):
+        conn = _state.require_connection()
+        count = conn.execute("SELECT COUNT(*) FROM icmp_messages").fetchone()[0]
+        assert count == ICMP_PACKET_COUNT
+
+    def test_summary_n_packets(self, ingested_db):
+        assert ingested_db["n_packets"] == TOTAL_IP
+
+    def test_summary_has_protocol_counts(self, ingested_db):
+        assert isinstance(ingested_db["protocol_counts"], list)
+        assert len(ingested_db["protocol_counts"]) > 0
+
+    def test_summary_has_top_talkers(self, ingested_db):
+        assert isinstance(ingested_db["top_talkers"], list)
+        assert len(ingested_db["top_talkers"]) > 0
+
+    def test_summary_has_time_bounds(self, ingested_db):
+        assert ingested_db["time_start"] is not None
+        assert ingested_db["time_end"] is not None
+        assert ingested_db["time_end"] >= ingested_db["time_start"]
+
+    def test_first_ingest_not_cached(self, ingested_db):
+        assert ingested_db["cached"] is False
+
+
+class TestIngestCaching:
+    def test_second_ingest_returns_cached(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        result1 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        result2 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert result1["cached"] is False
+        assert result2["cached"] is True
+
+    def test_cached_result_has_correct_packet_count(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        result2 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert result2["n_packets"] == TOTAL_IP
+
+    def test_cached_result_has_protocol_counts(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        result2 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert isinstance(result2["protocol_counts"], list)
+        assert len(result2["protocol_counts"]) > 0
+
+    def test_cached_result_has_top_talkers(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        result2 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert isinstance(result2["top_talkers"], list)
+        assert len(result2["top_talkers"]) > 0


### PR DESCRIPTION
## Summary

Adds `ingest_pcap`, `get_protocol_breakdown`, and `get_top_talkers` tools
backed by a shared DuckDB connection in `_state.py`. On ingest, the tool
checks a cache before parsing, then auto-runs both analysis tools and
returns a summary with packet count, time bounds, protocol breakdown, and
top talkers.

Follow-up commits harden connection lifecycle: reuse the existing handle
when re-ingesting the same file, close the previous handle when switching
to a different database, and ensure a newly opened connection is closed if
schema initialisation fails.

Closes #4

## Changes

- `tools/ingest.py`: `ingest_pcap` — parse, persist, cache, and summarise
  a PCAP file; reuses or closes the existing DuckDB connection as needed
- `tools/analysis.py`: `get_protocol_breakdown` and `get_top_talkers`;
  NULL guard on `proto_num`; early return for `n <= 0`
- `tools/_state.py`: shared connection module with `get_connection()`
  accessor and a single-threaded-use docstring
- `tests/conftest.py`: `ingested_conn` session fixture backed by
  `_state.get_connection()`
- `tests/test_ingest.py`: table-count tests use `ingested_conn`; `_restore_state`
  uses public accessors and closes replaced connections
- `tests/test_analysis_tools.py`: full coverage of both analysis tools

## Testing

72 tests, all passing:

```
python -m pytest tests/ -q
# 72 passed in ~13s
```
