### PR TITLE
feat(tools): add SQL query tool with safety guardrails

### DIFF
--- a/src/pcap_agent/tools/query.py
+++ b/src/pcap_agent/tools/query.py
@@ -1,0 +1,66 @@
+"""Query tool: validate and execute SQL against the DuckDB packet database."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import duckdb
+
+from pcap_agent.tools import _state
+
+_MAX_ROWS = 500
+
+# Statements allowed to execute against the packet database.
+_ALLOWED_STMT_RE = re.compile(
+    r"^\s*(SELECT|WITH|CREATE\s+TEMP\s+VIEW|CREATE\s+TEMPORARY\s+VIEW)\b",
+    re.IGNORECASE,
+)
+
+
+def query(sql: str) -> dict[str, Any]:
+    """Execute a SQL statement and return up to 500 rows as a list of dicts.
+
+    Only SELECT and CREATE TEMP VIEW statements are permitted. All others are
+    rejected before execution with a structured error dict. Malformed SQL that
+    DuckDB cannot parse also returns a structured error dict. Unexpected
+    exceptions propagate.
+
+    Return shape on success:
+        {"rows": [...], "truncated": bool, "row_count": int}
+
+    Return shape on error:
+        {"error": str, "hint": str}
+    """
+    if not _ALLOWED_STMT_RE.match(sql):
+        stmt_type = sql.strip().split()[0].upper() if sql.strip() else "(empty)"
+        return {
+            "error": f"Statement type '{stmt_type}' is not allowed.",
+            "hint": "Only SELECT and CREATE TEMP VIEW statements are permitted.",
+        }
+
+    conn = _state.require_connection()
+
+    try:
+        relation = conn.execute(sql)
+    except duckdb.Error as exc:
+        return {
+            "error": str(exc),
+            "hint": "Check your SQL syntax and column/table names.",
+        }
+
+    if relation is None:
+        # CREATE TEMP VIEW succeeds with no result set
+        return {"rows": [], "truncated": False, "row_count": 0}
+
+    columns = [desc[0] for desc in relation.description]
+    fetched = relation.fetchmany(_MAX_ROWS + 1)
+
+    truncated = len(fetched) > _MAX_ROWS
+    rows = fetched[:_MAX_ROWS]
+
+    return {
+        "rows": [dict(zip(columns, row)) for row in rows],
+        "truncated": truncated,
+        "row_count": len(rows),
+    }

--- a/src/pcap_agent/tools/query.py
+++ b/src/pcap_agent/tools/query.py
@@ -49,8 +49,9 @@ def query(sql: str) -> dict[str, Any]:
             "hint": "Check your SQL syntax and column/table names.",
         }
 
-    if relation is None:
-        # CREATE TEMP VIEW succeeds with no result set
+    if relation is None or relation.description is None:
+        # CREATE TEMP VIEW succeeds with no result set; DuckDB returns the
+        # connection object (never None) for DDL, so check description instead.
         return {"rows": [], "truncated": False, "row_count": 0}
 
     columns = [desc[0] for desc in relation.description]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,5 +1,6 @@
 """Integration tests for tools.ingest.ingest_pcap."""
 
+import duckdb
 import pytest
 from constants import (
     ICMP_PACKET_COUNT,
@@ -8,20 +9,28 @@ from constants import (
     UDP_TOTAL,
 )
 
-from pcap_agent.tools import _state  # noqa: F401 — used by _restore_state
+from pcap_agent.tools import _state
 from pcap_agent.tools.ingest import ingest_pcap
 
 
 @pytest.fixture
 def _restore_state():
-    """Restore _state after a test that temporarily changes the connection."""
-    saved_conn = _state.get_connection()
+    """Restore _state after a test that temporarily changes the connection.
+
+    ingest_pcap closes the previous connection when switching databases, so we
+    cannot restore the saved connection object — it will already be closed.
+    Instead we re-open the saved db_path after the test.
+    """
     saved_path = _state.get_db_path()
     yield
     new_conn = _state.get_connection()
-    _state.reset(saved_conn, saved_path)
-    if new_conn is not None and new_conn is not saved_conn:
+    if new_conn is not None:
         new_conn.close()
+    if saved_path is not None:
+        restored = duckdb.connect(saved_path)
+        _state.set_connection(restored, saved_path)
+    else:
+        _state.reset()
 
 
 class TestIngestPcap:

--- a/tests/test_query_tool.py
+++ b/tests/test_query_tool.py
@@ -1,0 +1,110 @@
+"""Integration tests for tools.query: SQL guardrails and result handling."""
+
+import pytest
+from constants import TOTAL_FRAMES
+
+from pcap_agent.tools import _state
+from pcap_agent.tools.query import _MAX_ROWS, query
+
+
+class TestSelectQueries:
+    def test_select_returns_list_of_dicts(self, ingested_db):
+        result = query("SELECT src_ip, dst_ip FROM packets LIMIT 5")
+        assert isinstance(result["rows"], list)
+        assert len(result["rows"]) == 5
+        assert set(result["rows"][0].keys()) == {"src_ip", "dst_ip"}
+
+    def test_select_all_returns_up_to_max_rows(self, ingested_db):
+        result = query("SELECT * FROM packets")
+        assert result["row_count"] <= _MAX_ROWS
+
+    def test_truncation_flag_false_when_within_limit(self, ingested_db):
+        # TOTAL_FRAMES (278) < _MAX_ROWS (500), so no truncation expected.
+        assert TOTAL_FRAMES < _MAX_ROWS
+        result = query("SELECT * FROM packets")
+        assert result["truncated"] is False
+        assert result["row_count"] == TOTAL_FRAMES
+
+    def test_truncation_flag_true_when_over_limit(self, ingested_db):
+        # Build a large synthetic result by cross-joining packets with itself.
+        sql = (
+            "SELECT a.src_ip FROM packets a "
+            "CROSS JOIN packets b "
+            f"LIMIT {_MAX_ROWS + 10}"
+        )
+        result = query(sql)
+        assert result["truncated"] is True
+        assert result["row_count"] == _MAX_ROWS
+
+    def test_row_count_matches_rows_length(self, ingested_db):
+        result = query("SELECT * FROM packets LIMIT 10")
+        assert result["row_count"] == len(result["rows"])
+
+    def test_with_clause_allowed(self, ingested_db):
+        sql = "WITH t AS (SELECT src_ip FROM packets LIMIT 3) SELECT * FROM t"
+        result = query(sql)
+        assert "error" not in result
+        assert len(result["rows"]) == 3
+
+
+class TestCreateTempView:
+    def test_create_temp_view_succeeds(self, ingested_db):
+        sql = "CREATE TEMP VIEW tcp_only AS SELECT * FROM packets WHERE protocol = 6"
+        result = query(sql)
+        assert "error" not in result
+        assert result["rows"] == []
+        assert result["truncated"] is False
+
+
+class TestRejectedStatements:
+    def test_drop_table_rejected(self, ingested_db):
+        result = query("DROP TABLE packets")
+        assert "error" in result
+        assert "hint" in result
+        assert "DROP" in result["error"]
+
+    def test_insert_rejected(self, ingested_db):
+        result = query("INSERT INTO packets SELECT * FROM packets LIMIT 1")
+        assert "error" in result
+        assert "hint" in result
+        assert "INSERT" in result["error"]
+
+    def test_update_rejected(self, ingested_db):
+        result = query("UPDATE packets SET src_ip = '0.0.0.0'")
+        assert "error" in result
+        assert "hint" in result
+
+    def test_delete_rejected(self, ingested_db):
+        result = query("DELETE FROM packets WHERE 1=1")
+        assert "error" in result
+        assert "hint" in result
+
+
+class TestMalformedSQL:
+    def test_bad_syntax_returns_error_dict(self, ingested_db):
+        result = query("SELECT FROM WHERE")
+        assert "error" in result
+        assert "hint" in result
+
+    def test_unknown_column_returns_error_dict(self, ingested_db):
+        result = query("SELECT nonexistent_column FROM packets")
+        assert "error" in result
+        assert "hint" in result
+
+    def test_unknown_table_returns_error_dict(self, ingested_db):
+        result = query("SELECT * FROM no_such_table")
+        assert "error" in result
+        assert "hint" in result
+
+
+class TestNoConnection:
+    def test_raises_when_no_connection(self):
+        original_conn = _state.get_connection()
+        original_path = _state.get_db_path()
+        _state.reset()
+        try:
+            with pytest.raises(RuntimeError, match="No PCAP ingested yet"):
+                query("SELECT 1")
+        finally:
+            if original_conn is not None:
+                _state.set_connection(original_conn, original_path)


### PR DESCRIPTION
## Summary

Adds a `query` tool that lets the agent run validated SQL against the DuckDB packet database. Only `SELECT` (including CTEs) and `CREATE TEMP VIEW` statements are permitted; all others are rejected before reaching the database. Results are capped at 500 rows with a truncation flag. Expected errors return structured `{"error", "hint"}` dicts so the agent can self-correct without crashing.

Also fixes a connection-leak bug in the `_restore_state` test fixture: `ingest_pcap` closes the previous DuckDB connection when switching databases, so the fixture now re-opens the saved path rather than trying to restore an already-closed connection handle.

## Changes

- `src/pcap_agent/tools/query.py` — new query tool with regex-based allowlist guardrail, 500-row cap, and structured error returns
- Fixed `if relation is None` guard to also check `relation.description is None` — DuckDB's `execute()` returns the connection object (never `None`) for DDL statements, so the old check was never entered
- `tests/test_ingest.py` — `_restore_state` fixture now re-opens the saved DB path via `duckdb.connect()` instead of restoring a closed connection handle
- `tests/test_query_tool.py` — 15 integration tests covering SELECT, CTEs, CREATE TEMP VIEW, rejected statements, malformed SQL, and the no-connection error path

## Testing

All tests pass:

```
uv run pytest
```

## Related Issues

Closes #5
