### PR TITLE
feat(agent,cli): add conversational interface and CLI entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# pcap-agent
+
+AI agent that ingests PCAP files into DuckDB and answers questions about network traffic.
+
+## Stack
+
+- **Python 3.13**, managed with **uv** (never use pip3 directly — always `uv add`)
+- **DuckDB** for packet storage and query
+- **Polars** DataFrames from the parser layer; inserted row-by-row via `executemany`
+- **Scapy** for PCAP parsing
+- **chatlas** for the agent loop
+- **ruff** (`E`, `F`, `I` rules, line length 88) — run `uv run ruff check` before committing
+- **pytest** — run with `uv run pytest`
+
+## Project layout
+
+```
+src/pcap_agent/
+  config.py          # frozen Config dataclass, loaded from env/.env
+  agent.py           # create_agent() — ChatAnthropic session + all 7 tools registered
+  cli.py             # click entry point: flags, spinner ingest, console/app dispatch
+  db.py              # DuckDB schema DDL, ingest(), get_cached()/set_cached()
+  parser.py          # Scapy → Polars DataFrames (ParsedPcap)
+  tools/
+    _state.py        # module-level singleton connection: set/get/require/reset
+    ingest.py        # ingest_pcap() — parse + persist + auto-run analysis
+    analysis.py      # get_protocol_breakdown(), get_top_talkers()
+    query.py         # query() — validated ad-hoc SQL with safety guardrails
+    detection.py     # detect_port_scans(), detect_anomalies() — on-demand only
+    reassembly.py    # reassemble_stream() — TCP/UDP payload reassembly with 64 KB cap
+tests/
+  conftest.py        # session fixtures: synthetic_pcap, ingested_db, ingested_conn
+  constants.py       # packet counts and IPs shared across all test files
+```
+
+## Architecture decisions
+
+- **Single shared connection** (`tools/_state.py`): all tools share one DuckDB connection per session. No locking; single-threaded CLI use only.
+- **Tools return plain dicts** so the agent can serialize and reason about results.
+- **Expected errors return structured dicts** `{"error": ..., "hint": ...}`; unexpected exceptions propagate. This lets the agent self-correct on bad input without crashing.
+- **`ingest_pcap` closes the previous connection** when switching to a different DB file (DuckDB single-writer constraint). Any fixture or caller that holds a reference to the old connection object must re-open by path, not restore the closed handle.
+
+## Schema
+
+```sql
+packets        (packet_id PK, timestamp, src_ip, dst_ip, protocol, length, ttl)
+tcp_segments   (packet_id, sport, dport, flags, seq, ack, payload)
+udp_datagrams  (packet_id, sport, dport, payload)
+icmp_messages  (packet_id, type, code, payload)
+pcap_meta      (sha256 PK, pcap_path, ingested_at)  -- caching table
+```
+
+## Adding a new tool
+
+1. Create `src/pcap_agent/tools/<name>.py`
+2. Call `_state.require_connection()` to get the connection — raises `RuntimeError` if no PCAP ingested yet
+3. Return plain dicts; return `{"error": ..., "hint": ...}` for expected failures
+4. Add integration tests in `tests/test_<name>_tool.py` using the `ingested_db` session fixture
+5. Run `uv run ruff check` and `uv run pytest`
+
+## Testing patterns
+
+- **`ingested_db`** (session-scoped): ingests the synthetic PCAP once; sets `_state._conn`. Use this for any test that needs data in the DB.
+- **`ingested_conn`**: returns `_state.require_connection()` after `ingested_db` runs. Use when you need the raw connection.
+- **`duckdb_conn`** (function-scoped): fresh in-memory connection with schema. Use for DB-layer unit tests that don't need the full ingest pipeline.
+- **`_restore_state`** (in `test_ingest.py`): saves `_state._db_path` before the test, closes the post-test connection, and **re-opens** the saved path — because `ingest_pcap` closes the previous connection on DB switch, making object-level restore impossible.
+
+### Test isolation pitfall
+`ingest_pcap` closes `_state._conn` when switching databases. Never try to restore a saved connection object after calling `ingest_pcap` with a different `db_dir` — it will already be closed. Re-open via `duckdb.connect(saved_path)` instead.
+
+### DuckDB BLOB sizing
+Use `OCTET_LENGTH(col)` to measure byte length of `BLOB` columns. `LENGTH()` is not overloaded for `BLOB` in DuckDB and raises a `BinderException` at runtime.
+
+### IsolationForest contamination calibration
+The contamination parameter controls the percentile threshold, not a strict count. `contamination=c` flags all samples whose score falls below `np.percentile(scores, 100*c)`. For a fixture with well-separated anomalies, calibrate by running the detector at increasing contamination values until all known-anomalous packets appear; the required value may be higher than `n_anomalies / n_total` due to score clustering near the boundary.
+
+### Temporarily swapping `_state._conn` in function-scoped fixtures
+When a tool test needs custom data (e.g. binary payloads, oversized chunks) that the shared session fixture doesn't provide, use `duckdb_conn` and swap the singleton inside a function-scoped fixture:
+
+```python
+@pytest.fixture()
+def custom_conn(self, duckdb_conn):
+    # insert custom rows...
+    old = _state.get_connection()
+    old_path = _state.get_db_path()
+    _state.set_connection(duckdb_conn, ":memory:")
+    yield duckdb_conn
+    _state.set_connection(old, old_path) if old else _state.reset()
+```
+
+This keeps the session `_state._conn` intact for all other test files.
+
+### Test file ordering matters
+pytest collects files alphabetically. Tests in `test_query_tool.py` run after `test_ingest.py::TestIngestCaching`, which temporarily replaces the session connection. The `_restore_state` fixture must leave `_state._conn` in a valid open state or later test files will see a closed connection.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | (required) | Claude API key |
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | Model to use |
+| `PCAP_AGENT_DB_DIR` | `~/.cache/pcap-agent` | Where DuckDB files are stored |
+| `PCAP_AGENT_UI` | `console` | UI mode |
+| `PCAP_AGENT_VERBOSE` | `""` | Enable verbose logging |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | OpenTelemetry OTLP endpoint |
+
+Tests set `ANTHROPIC_API_KEY=test-dummy-key` via `pytest_configure` in `conftest.py`.
+
+## CLI config loading order
+
+`config.py` runs `_load()` at module import time and raises if `ANTHROPIC_API_KEY` is unset. The CLI sets `os.environ` values from click flags **before** importing any `pcap_agent` module that transitively imports `config`. Keep all `pcap_agent` imports inside the command function body, not at the top of `cli.py`.
+
+## Justfile targets
+
+| Target | Description |
+|---|---|
+| `just setup` | Install dependencies and pre-commit hooks |
+| `just test` | Run the test suite |
+| `just lint` | Run ruff over `src` and `tests` |
+| `just run-repl [args...]` | Start the console REPL; pass any CLI flags or a PCAP path as extra args |
+| `just run-app [args...]` | Start the Shiny web UI; same variadic args |
+
+## Branch naming
+
+`dsk-<issue-number>-<short-slug>` — e.g. `dsk-5-query-tool-sql-guardrails`

--- a/Justfile
+++ b/Justfile
@@ -8,3 +8,9 @@ test:
 
 lint:
     uv run ruff check src tests
+
+run-repl *args="":
+    uv run pcap-agent --ui console {{ args }}
+
+run-app *args="":
+    uv run pcap-agent --ui app {{ args }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "pcap-agent"
 version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
+    "anthropic>=0.97.0",
     "chatlas>=0.16.0",
     "click>=8.3.3",
     "duckdb>=1.5.2",
@@ -22,6 +23,9 @@ dev = [
     "pytest>=9.0.3",
     "ruff>=0.15.12",
 ]
+
+[project.scripts]
+pcap-agent = "pcap_agent.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -1,0 +1,39 @@
+"""Agent: chatlas session wired with all PCAP analysis tools."""
+
+from chatlas import ChatAnthropic
+
+from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
+from pcap_agent.tools.detection import detect_anomalies, detect_port_scans
+from pcap_agent.tools.ingest import ingest_pcap
+from pcap_agent.tools.query import query
+from pcap_agent.tools.reassembly import reassemble_stream
+
+_SYSTEM_PROMPT = """\
+You are a terse, experienced network security analyst.
+
+Guidelines:
+- If the user mentions a PCAP file path and no data has been ingested yet, \
+call ingest_pcap before answering.
+- If no PCAP has been ingested and no path is known, ask the user for a file path.
+- Interpret tool results in 2-3 plain-English sentences. Be concise.
+- Render any tabular data as a markdown table.
+- After each answer, suggest one or two follow-up angles the analyst should consider.
+- Do not explain what the tools do unless asked.
+"""
+
+
+def create_agent(*, api_key: str, model: str) -> "ChatAnthropic":
+    """Return a ChatAnthropic session with all 7 analysis tools registered."""
+    chat = ChatAnthropic(
+        system_prompt=_SYSTEM_PROMPT,
+        model=model,
+        api_key=api_key,
+    )
+    chat.register_tool(ingest_pcap)
+    chat.register_tool(get_protocol_breakdown)
+    chat.register_tool(get_top_talkers)
+    chat.register_tool(query)
+    chat.register_tool(detect_port_scans)
+    chat.register_tool(detect_anomalies)
+    chat.register_tool(reassemble_stream)
+    return chat

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -44,7 +44,6 @@ import click
 )
 @click.option(
     "--verbose",
-    envvar="PCAP_AGENT_VERBOSE",
     is_flag=True,
     default=False,
     help="Enable verbose logging [env: PCAP_AGENT_VERBOSE]",
@@ -62,6 +61,8 @@ def main(
 
     Optionally provide a PCAP_FILE to ingest before starting the chat session.
     """
+    verbose = verbose or bool(os.environ.get("PCAP_AGENT_VERBOSE", ""))
+
     if not api_key:
         click.echo(
             "Error: ANTHROPIC_API_KEY is not set. "
@@ -92,7 +93,9 @@ def main(
             transient=True,
         ) as progress:
             progress.add_task(f"Ingesting {pcap_file}…", total=None)
-            ingest_pcap(pcap_file, db_dir=db_dir_expanded)
+            result = ingest_pcap(pcap_file, db_dir=db_dir_expanded)
+        if not result.get("n_packets"):
+            click.echo("Warning: no packets were ingested from the file.", err=True)
 
     from pcap_agent.agent import create_agent
 

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -1,0 +1,104 @@
+"""CLI entry point for pcap-agent."""
+
+import os
+import sys
+
+import click
+
+
+@click.command()
+@click.argument("pcap_file", required=False, type=click.Path(exists=True))
+@click.option(
+    "--api-key",
+    envvar="ANTHROPIC_API_KEY",
+    default="",
+    help="Anthropic API key [env: ANTHROPIC_API_KEY]",
+)
+@click.option(
+    "--model",
+    envvar="ANTHROPIC_MODEL",
+    default="claude-sonnet-4-6",
+    show_default=True,
+    help="Claude model name [env: ANTHROPIC_MODEL]",
+)
+@click.option(
+    "--ui",
+    envvar="PCAP_AGENT_UI",
+    default="console",
+    show_default=True,
+    type=click.Choice(["console", "app"]),
+    help="UI mode: console (REPL) or app (Shiny web UI) [env: PCAP_AGENT_UI]",
+)
+@click.option(
+    "--db-dir",
+    envvar="PCAP_AGENT_DB_DIR",
+    default="~/.cache/pcap-agent",
+    show_default=True,
+    help="Directory for DuckDB storage [env: PCAP_AGENT_DB_DIR]",
+)
+@click.option(
+    "--otlp-endpoint",
+    envvar="OTEL_EXPORTER_OTLP_ENDPOINT",
+    default="",
+    help="OpenTelemetry OTLP exporter endpoint [env: OTEL_EXPORTER_OTLP_ENDPOINT]",
+)
+@click.option(
+    "--verbose",
+    envvar="PCAP_AGENT_VERBOSE",
+    is_flag=True,
+    default=False,
+    help="Enable verbose logging [env: PCAP_AGENT_VERBOSE]",
+)
+def main(
+    pcap_file: str | None,
+    api_key: str,
+    model: str,
+    ui: str,
+    db_dir: str,
+    otlp_endpoint: str,
+    verbose: bool,
+) -> None:
+    """PCAP analysis agent powered by Claude.
+
+    Optionally provide a PCAP_FILE to ingest before starting the chat session.
+    """
+    if not api_key:
+        click.echo(
+            "Error: ANTHROPIC_API_KEY is not set. "
+            "Provide it via --api-key or the ANTHROPIC_API_KEY environment variable.",
+            err=True,
+        )
+        sys.exit(1)
+
+    db_dir_expanded = os.path.expanduser(db_dir)
+
+    # Set env vars before importing config-dependent modules so the module-level
+    # config singleton sees the values resolved from CLI flags.
+    os.environ["ANTHROPIC_API_KEY"] = api_key
+    os.environ["ANTHROPIC_MODEL"] = model
+    os.environ["PCAP_AGENT_UI"] = ui
+    os.environ["PCAP_AGENT_DB_DIR"] = db_dir_expanded
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint
+    os.environ["PCAP_AGENT_VERBOSE"] = "1" if verbose else ""
+
+    if pcap_file:
+        from rich.progress import Progress, SpinnerColumn, TextColumn
+
+        from pcap_agent.tools.ingest import ingest_pcap
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            transient=True,
+        ) as progress:
+            progress.add_task(f"Ingesting {pcap_file}…", total=None)
+            ingest_pcap(pcap_file, db_dir=db_dir_expanded)
+
+    from pcap_agent.agent import create_agent
+
+    chat = create_agent(api_key=api_key, model=model)
+
+    if ui == "app":
+        chat.app()
+    else:
+        chat.console()

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.97.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -156,6 +175,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -696,6 +724,7 @@ name = "pcap-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "chatlas" },
     { name = "click" },
     { name = "duckdb" },
@@ -718,6 +747,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.97.0" },
     { name = "chatlas", specifier = ">=0.16.0" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "duckdb", specifier = ">=1.5.2" },


### PR DESCRIPTION
## Summary

Wires a `ChatAnthropic`-backed agent with all seven PCAP analysis tools
and adds a `click` CLI entry point (`pcap-agent`) that resolves config
from flags or environment variables. An optional `PCAP_FILE` argument
pre-ingests the capture with a Rich spinner before starting the chat
session.

## Changes

- `agent.py`: creates a `ChatAnthropic` session with a terse network
  security analyst system prompt and registers all 7 tools
  (`ingest_pcap`, `get_protocol_breakdown`, `get_top_talkers`, `query`,
  `detect_port_scans`, `detect_anomalies`, `reassemble_stream`)
- `cli.py`: `click` entry point accepting `--api-key`, `--model`,
  `--ui`, `--db-dir`, `--otlp-endpoint`, and `--verbose`; each readable
  from its corresponding environment variable; exits immediately with a
  clear error if `ANTHROPIC_API_KEY` is unset
- Warns on stderr when `ingest_pcap` returns 0 packets so the user is
  not silently dropped into an empty session
- Resolves `PCAP_AGENT_VERBOSE` manually inside the function body instead
  of using click's `envvar` + `is_flag` wiring (which treats any
  non-empty string as truthy, conflicting with the empty-string-disabled
  convention)
- `pyproject.toml`: adds `anthropic>=0.97.0` dependency and registers
  the `pcap-agent` console script
- `Justfile`: adds `run-repl` and `run-app` targets with variadic args
  for passing extra flags or a PCAP path
- `CLAUDE.md`: documents all Justfile targets

## Testing

```bash
# Install and run with a PCAP file
uv run pcap-agent path/to/capture.pcap

# Console REPL without a file (agent will prompt for one)
just run-repl

# Web UI mode
just run-app path/to/capture.pcap

# Test missing API key handling
ANTHROPIC_API_KEY= uv run pcap-agent   # should exit with error message

# Run tests
just test
```

## Related Issues

Closes #8
