### PR TITLE
feat(telemetry): add OpenTelemetry observability for logs, traces, and metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ src/pcap_agent/
   cli.py             # click entry point: flags, spinner ingest, console/app dispatch
   db.py              # DuckDB schema DDL, ingest(), get_cached()/set_cached()
   parser.py          # Scapy → Polars DataFrames (ParsedPcap)
+  telemetry.py       # OTel SDK init (setup()), instrument_tool(), metric record helpers
   tools/
     _state.py        # module-level singleton connection: set/get/require/reset
     ingest.py        # ingest_pcap() — parse + persist + auto-run analysis
@@ -39,6 +40,7 @@ tests/
 - **Tools return plain dicts** so the agent can serialize and reason about results.
 - **Expected errors return structured dicts** `{"error": ..., "hint": ...}`; unexpected exceptions propagate. This lets the agent self-correct on bad input without crashing.
 - **`ingest_pcap` closes the previous connection** when switching to a different DB file (DuckDB single-writer constraint). Any fixture or caller that holds a reference to the old connection object must re-open by path, not restore the closed handle.
+- **Telemetry is a no-op by default** (`telemetry.py`): `setup("")` skips all OTel SDK initialisation. All 7 tools are wrapped with `instrument_tool()` in `agent.py`; spans and metrics are only emitted when an OTLP endpoint is configured. Metric counters (`record_packets_ingested`, `record_queries_run`, `record_anomalies_detected`) live in the tool functions themselves so the CLI initial ingest also records metrics.
 
 ## Schema
 
@@ -90,6 +92,11 @@ def custom_conn(self, duckdb_conn):
 
 This keeps the session `_state._conn` intact for all other test files.
 
+### Testing OTel instrumentation without a real OTLP server
+Use `InMemorySpanExporter` and `InMemoryMetricReader` from the OTel SDK to unit-test spans and metrics without needing a running collector. Directly set `telemetry._tracer` / `telemetry._meter` / `telemetry._metrics` in the fixture instead of calling `setup()`, to avoid mutating global OTel provider state across tests. Call `telemetry._reset()` in `autouse` teardown.
+
+To patch multiple OTel symbols inside a function that does lazy imports (e.g. `setup()`), use `contextlib.ExitStack` — Python's `with` statement does not support `*`-unpacking a list of context managers.
+
 ### Test file ordering matters
 pytest collects files alphabetically. Tests in `test_query_tool.py` run after `test_ingest.py::TestIngestCaching`, which temporarily replaces the session connection. The `_restore_state` fixture must leave `_state._conn` in a valid open state or later test files will see a closed connection.
 
@@ -119,6 +126,8 @@ Tests set `ANTHROPIC_API_KEY=test-dummy-key` via `pytest_configure` in `conftest
 | `just lint` | Run ruff over `src` and `tests` |
 | `just run-repl [args...]` | Start the console REPL; pass any CLI flags or a PCAP path as extra args |
 | `just run-app [args...]` | Start the Shiny web UI; same variadic args |
+| `just grafana-up` | Start `grafana/otel-lgtm` container (Grafana on :3000, OTLP HTTP on :4318) |
+| `just grafana-down` | Stop and remove the Grafana container |
 
 ## Branch naming
 

--- a/Justfile
+++ b/Justfile
@@ -14,3 +14,15 @@ run-repl *args="":
 
 run-app *args="":
     uv run pcap-agent --ui app {{ args }}
+
+grafana-up:
+    docker run -d --name pcap-agent-grafana \
+        -p 3000:3000 \
+        -p 4317:4317 \
+        -p 4318:4318 \
+        grafana/otel-lgtm:latest
+    @echo "Grafana running at http://localhost:3000"
+    @echo "OTLP endpoint at http://localhost:4318"
+
+grafana-down:
+    docker stop pcap-agent-grafana && docker rm pcap-agent-grafana

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "click>=8.3.3",
     "duckdb>=1.5.2",
     "opentelemetry-exporter-otlp-proto-grpc>=1.41.1",
+    "opentelemetry-exporter-otlp-proto-http>=1.41.1",
     "opentelemetry-instrumentation-logging>=0.62b1",
     "opentelemetry-sdk>=1.41.1",
     "polars>=1.40.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "chatlas>=0.16.0",
     "click>=8.3.3",
     "duckdb>=1.5.2",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.41.1",
     "opentelemetry-exporter-otlp-proto-http>=1.41.1",
     "opentelemetry-instrumentation-logging>=0.62b1",
     "opentelemetry-sdk>=1.41.1",

--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -2,6 +2,7 @@
 
 from chatlas import ChatAnthropic
 
+from pcap_agent import telemetry
 from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
 from pcap_agent.tools.detection import detect_anomalies, detect_port_scans
 from pcap_agent.tools.ingest import ingest_pcap
@@ -29,11 +30,11 @@ def create_agent(*, api_key: str, model: str) -> "ChatAnthropic":
         model=model,
         api_key=api_key,
     )
-    chat.register_tool(ingest_pcap)
-    chat.register_tool(get_protocol_breakdown)
-    chat.register_tool(get_top_talkers)
-    chat.register_tool(query)
-    chat.register_tool(detect_port_scans)
-    chat.register_tool(detect_anomalies)
-    chat.register_tool(reassemble_stream)
+    chat.register_tool(telemetry.instrument_tool(ingest_pcap))
+    chat.register_tool(telemetry.instrument_tool(get_protocol_breakdown))
+    chat.register_tool(telemetry.instrument_tool(get_top_talkers))
+    chat.register_tool(telemetry.instrument_tool(query))
+    chat.register_tool(telemetry.instrument_tool(detect_port_scans))
+    chat.register_tool(telemetry.instrument_tool(detect_anomalies))
+    chat.register_tool(telemetry.instrument_tool(reassemble_stream))
     return chat

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -82,6 +82,10 @@ def main(
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint
     os.environ["PCAP_AGENT_VERBOSE"] = "1" if verbose else ""
 
+    from pcap_agent import telemetry
+
+    telemetry.setup(otlp_endpoint, verbose)
+
     if pcap_file:
         from rich.progress import Progress, SpinnerColumn, TextColumn
 

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -1,0 +1,150 @@
+"""OpenTelemetry SDK initialisation and instrumentation helpers."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import time
+from typing import Any, Callable
+
+_tracer: Any = None
+_meter: Any = None
+_metrics: dict[str, Any] = {}
+
+
+def setup(endpoint: str = "", verbose: bool = False) -> None:
+    """Initialize OTel SDK with OTLP HTTP exporters. No-op if endpoint is empty."""
+    global _tracer, _meter, _metrics
+
+    if not endpoint:
+        return
+
+    from opentelemetry import metrics as otel_metrics
+    from opentelemetry import trace
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+        OTLPMetricExporter,
+    )
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    base = endpoint.rstrip("/")
+    resource = Resource.create({"service.name": "pcap-agent"})
+
+    # Traces
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{base}/v1/traces"))
+    )
+    trace.set_tracer_provider(tp)
+    _tracer = trace.get_tracer("pcap-agent")
+
+    # Metrics
+    reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint=f"{base}/v1/metrics")
+    )
+    mp = MeterProvider(resource=resource, metric_readers=[reader])
+    otel_metrics.set_meter_provider(mp)
+    _meter = otel_metrics.get_meter("pcap-agent")
+
+    _metrics["packets_ingested"] = _meter.create_counter(
+        "pcap_agent.packets_ingested",
+        description="Total packets ingested",
+    )
+    _metrics["queries_run"] = _meter.create_counter(
+        "pcap_agent.queries_run",
+        description="Total SQL queries run",
+    )
+    _metrics["anomalies_detected"] = _meter.create_counter(
+        "pcap_agent.anomalies_detected",
+        description="Total anomalies detected",
+    )
+    _metrics["tool_call_latency"] = _meter.create_histogram(
+        "pcap_agent.tool_call_latency",
+        unit="s",
+        description="Tool call latency in seconds",
+    )
+
+    # Logs bridge
+    lp = LoggerProvider(resource=resource)
+    lp.add_log_record_processor(
+        BatchLogRecordProcessor(OTLPLogExporter(endpoint=f"{base}/v1/logs"))
+    )
+    set_logger_provider(lp)
+    LoggingInstrumentor().instrument(set_logging_format=verbose)
+
+
+def instrument_tool(func: Callable) -> Callable:
+    """Wrap a tool function in an OTel span with arguments as attributes.
+
+    Returns the original function unchanged when telemetry is not configured.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if _tracer is None:
+            return func(*args, **kwargs)
+
+        tool_name = func.__name__
+        with _tracer.start_as_current_span(tool_name) as span:
+            span.set_attribute("tool.name", tool_name)
+            try:
+                sig = inspect.signature(func)
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                for k, v in bound.arguments.items():
+                    span.set_attribute(f"tool.arg.{k}", str(v))
+            except (TypeError, ValueError):
+                pass
+
+            t0 = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                elapsed = time.perf_counter() - t0
+                _record_latency(tool_name, elapsed)
+
+    return wrapper
+
+
+def record_packets_ingested(count: int) -> None:
+    """Increment the packets-ingested counter."""
+    counter = _metrics.get("packets_ingested")
+    if counter is not None:
+        counter.add(count)
+
+
+def record_queries_run() -> None:
+    """Increment the queries-run counter."""
+    counter = _metrics.get("queries_run")
+    if counter is not None:
+        counter.add(1)
+
+
+def record_anomalies_detected(count: int) -> None:
+    """Increment the anomalies-detected counter."""
+    counter = _metrics.get("anomalies_detected")
+    if counter is not None:
+        counter.add(count)
+
+
+def _record_latency(tool_name: str, elapsed: float) -> None:
+    hist = _metrics.get("tool_call_latency")
+    if hist is not None:
+        hist.record(elapsed, {"tool": tool_name})
+
+
+def _reset() -> None:
+    """Reset module state. For testing only."""
+    global _tracer, _meter, _metrics
+    _tracer = None
+    _meter = None
+    _metrics = {}

--- a/src/pcap_agent/tools/detection.py
+++ b/src/pcap_agent/tools/detection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 from sklearn.ensemble import IsolationForest
 
+from pcap_agent import telemetry
 from pcap_agent.tools import _state
 
 _PORT_SCAN_SQL = """
@@ -126,8 +127,10 @@ def detect_anomalies(contamination: float = 0.02) -> list[dict] | dict:
     labels = clf.fit_predict(X)
     scores = clf.score_samples(X)
 
-    return [
+    anomalies = [
         {**rec, "anomaly_score": round(float(score), 6)}
         for rec, label, score in zip(records, labels, scores)
         if label == -1
     ]
+    telemetry.record_anomalies_detected(len(anomalies))
+    return anomalies

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import duckdb
 
-from pcap_agent import db, parser
+from pcap_agent import db, parser, telemetry
 from pcap_agent.config import config
 from pcap_agent.tools import _state
 from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
@@ -67,6 +67,8 @@ def _summary(
     cached: bool,
 ) -> dict[str, Any]:
     n_packets = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+    if not cached:
+        telemetry.record_packets_ingested(n_packets)
     row = conn.execute(
         "SELECT MIN(timestamp), MAX(timestamp) FROM packets"
     ).fetchone()

--- a/src/pcap_agent/tools/query.py
+++ b/src/pcap_agent/tools/query.py
@@ -41,10 +41,10 @@ def query(sql: str) -> dict[str, Any]:
         }
 
     conn = _state.require_connection()
-    telemetry.record_queries_run()
 
     try:
         relation = conn.execute(sql)
+        telemetry.record_queries_run()
     except duckdb.Error as exc:
         return {
             "error": str(exc),

--- a/src/pcap_agent/tools/query.py
+++ b/src/pcap_agent/tools/query.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import duckdb
 
+from pcap_agent import telemetry
 from pcap_agent.tools import _state
 
 _MAX_ROWS = 500
@@ -40,6 +41,7 @@ def query(sql: str) -> dict[str, Any]:
         }
 
     conn = _state.require_connection()
+    telemetry.record_queries_run()
 
     try:
         relation = conn.execute(sql)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,253 @@
+"""Tests for the telemetry module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pcap_agent.telemetry as telemetry
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry():
+    """Reset telemetry module state around each test."""
+    telemetry._reset()
+    yield
+    telemetry._reset()
+
+
+@pytest.fixture()
+def memory_telemetry():
+    """Configure telemetry with in-memory OTel exporters (no real OTLP server)."""
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    span_exporter = InMemorySpanExporter()
+    tp = TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(span_exporter))
+    telemetry._tracer = tp.get_tracer("test")
+
+    metric_reader = InMemoryMetricReader()
+    mp = MeterProvider(metric_readers=[metric_reader])
+    meter = mp.get_meter("test")
+    telemetry._meter = meter
+    telemetry._metrics = {
+        "packets_ingested": meter.create_counter("pcap_agent.packets_ingested"),
+        "queries_run": meter.create_counter("pcap_agent.queries_run"),
+        "anomalies_detected": meter.create_counter("pcap_agent.anomalies_detected"),
+        "tool_call_latency": meter.create_histogram("pcap_agent.tool_call_latency"),
+    }
+
+    return span_exporter, metric_reader
+
+
+def _get_metric_sum(metric_reader, name: str) -> float:
+    """Extract the sum for a named counter from InMemoryMetricReader."""
+    data = metric_reader.get_metrics_data()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    return sum(dp.value for dp in metric.data.data_points)
+    return 0.0
+
+
+def _get_histogram_count(metric_reader, name: str) -> int:
+    """Extract data point count for a named histogram."""
+    data = metric_reader.get_metrics_data()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    return sum(dp.count for dp in metric.data.data_points)
+    return 0
+
+
+class TestSetupNoOp:
+    def test_empty_endpoint_leaves_tracer_none(self):
+        telemetry.setup("")
+        assert telemetry._tracer is None
+
+    def test_empty_endpoint_leaves_meter_none(self):
+        telemetry.setup("")
+        assert telemetry._meter is None
+
+    def test_empty_endpoint_leaves_metrics_empty(self):
+        telemetry.setup("")
+        assert telemetry._metrics == {}
+
+    def test_no_args_does_not_raise(self):
+        telemetry.setup()
+
+    def test_empty_endpoint_does_not_raise(self):
+        telemetry.setup("")
+
+
+class TestSetupWithEndpoint:
+    def _patched_setup(self, mock_tracer: MagicMock, mock_meter: MagicMock) -> None:
+        """Call telemetry.setup() with all OTel SDK symbols mocked out."""
+        from contextlib import ExitStack
+
+        targets = [
+            ("opentelemetry.sdk.trace.TracerProvider", {}),
+            ("opentelemetry.sdk.trace.export.BatchSpanProcessor", {}),
+            (
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                {},
+            ),
+            ("opentelemetry.sdk.metrics.MeterProvider", {}),
+            ("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader", {}),
+            (
+                "opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter",
+                {},
+            ),
+            ("opentelemetry.sdk._logs.LoggerProvider", {}),
+            ("opentelemetry.sdk._logs.export.BatchLogRecordProcessor", {}),
+            (
+                "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+                {},
+            ),
+            ("opentelemetry._logs.set_logger_provider", {}),
+            ("opentelemetry.instrumentation.logging.LoggingInstrumentor", {}),
+            ("opentelemetry.trace.set_tracer_provider", {}),
+            ("opentelemetry.metrics.set_meter_provider", {}),
+            ("opentelemetry.trace.get_tracer", {"return_value": mock_tracer}),
+            ("opentelemetry.metrics.get_meter", {"return_value": mock_meter}),
+        ]
+        with ExitStack() as stack:
+            for target, kwargs in targets:
+                stack.enter_context(patch(target, **kwargs))
+            telemetry.setup("http://localhost:4318")
+
+    def test_endpoint_sets_tracer(self):
+        mock_tracer = MagicMock()
+        mock_meter = MagicMock()
+        mock_meter.create_counter.return_value = MagicMock()
+        mock_meter.create_histogram.return_value = MagicMock()
+        self._patched_setup(mock_tracer, mock_meter)
+        assert telemetry._tracer is mock_tracer
+
+    def test_endpoint_sets_meter(self):
+        mock_tracer = MagicMock()
+        mock_meter = MagicMock()
+        mock_meter.create_counter.return_value = MagicMock()
+        mock_meter.create_histogram.return_value = MagicMock()
+        self._patched_setup(mock_tracer, mock_meter)
+        assert telemetry._meter is mock_meter
+
+    def test_endpoint_creates_all_metric_instruments(self):
+        mock_tracer = MagicMock()
+        mock_meter = MagicMock()
+        mock_meter.create_counter.return_value = MagicMock()
+        mock_meter.create_histogram.return_value = MagicMock()
+        self._patched_setup(mock_tracer, mock_meter)
+        assert "packets_ingested" in telemetry._metrics
+        assert "queries_run" in telemetry._metrics
+        assert "anomalies_detected" in telemetry._metrics
+        assert "tool_call_latency" in telemetry._metrics
+
+
+class TestInstrumentTool:
+    def test_noop_without_setup_passes_through(self):
+        def my_tool(x: int) -> int:
+            return x * 2
+
+        wrapped = telemetry.instrument_tool(my_tool)
+        assert wrapped(3) == 6
+
+    def test_noop_preserves_function_name(self):
+        def my_tool(x: int) -> int:
+            return x
+
+        wrapped = telemetry.instrument_tool(my_tool)
+        assert wrapped.__name__ == "my_tool"
+
+    def test_span_created_with_tool_name(self, memory_telemetry):
+        span_exporter, _ = memory_telemetry
+
+        def sample_tool(x: int) -> dict:
+            return {"x": x}
+
+        wrapped = telemetry.instrument_tool(sample_tool)
+        wrapped(42)
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "sample_tool"
+
+    def test_span_has_tool_name_attribute(self, memory_telemetry):
+        span_exporter, _ = memory_telemetry
+
+        def sample_tool(x: int) -> dict:
+            return {"x": x}
+
+        wrapped = telemetry.instrument_tool(sample_tool)
+        wrapped(42)
+
+        spans = span_exporter.get_finished_spans()
+        assert spans[0].attributes["tool.name"] == "sample_tool"
+
+    def test_span_has_argument_attributes(self, memory_telemetry):
+        span_exporter, _ = memory_telemetry
+
+        def sample_tool(x: int, y: str = "default") -> dict:
+            return {"x": x, "y": y}
+
+        wrapped = telemetry.instrument_tool(sample_tool)
+        wrapped(42, y="hello")
+
+        spans = span_exporter.get_finished_spans()
+        assert spans[0].attributes["tool.arg.x"] == "42"
+        assert spans[0].attributes["tool.arg.y"] == "hello"
+
+    def test_span_records_latency_histogram(self, memory_telemetry):
+        _, metric_reader = memory_telemetry
+
+        def sample_tool() -> dict:
+            return {}
+
+        wrapped = telemetry.instrument_tool(sample_tool)
+        wrapped()
+
+        count = _get_histogram_count(metric_reader, "pcap_agent.tool_call_latency")
+        assert count == 1
+
+    def test_return_value_preserved(self, memory_telemetry):
+        def sample_tool(x: int) -> dict:
+            return {"result": x * 2}
+
+        wrapped = telemetry.instrument_tool(sample_tool)
+        assert wrapped(5) == {"result": 10}
+
+
+class TestMetricRecording:
+    def test_record_packets_ingested_noop_without_setup(self):
+        telemetry.record_packets_ingested(100)  # should not raise
+
+    def test_record_queries_run_noop_without_setup(self):
+        telemetry.record_queries_run()  # should not raise
+
+    def test_record_anomalies_detected_noop_without_setup(self):
+        telemetry.record_anomalies_detected(5)  # should not raise
+
+    def test_record_packets_ingested_increments_counter(self, memory_telemetry):
+        _, metric_reader = memory_telemetry
+        telemetry.record_packets_ingested(278)
+        assert _get_metric_sum(metric_reader, "pcap_agent.packets_ingested") == 278
+
+    def test_record_queries_run_increments_counter(self, memory_telemetry):
+        _, metric_reader = memory_telemetry
+        telemetry.record_queries_run()
+        telemetry.record_queries_run()
+        assert _get_metric_sum(metric_reader, "pcap_agent.queries_run") == 2
+
+    def test_record_anomalies_detected_increments_counter(self, memory_telemetry):
+        _, metric_reader = memory_telemetry
+        telemetry.record_anomalies_detected(3)
+        assert _get_metric_sum(metric_reader, "pcap_agent.anomalies_detected") == 3

--- a/uv.lock
+++ b/uv.lock
@@ -230,37 +230,6 @@ wheels = [
 ]
 
 [[package]]
-name = "grpcio"
-version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
-    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -588,24 +557,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.41.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/9b/e4503060b8695579dbaad187dc8cef4554188de68748c88060599b77489e/opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b", size = 25755, upload-time = "2026-04-24T13:15:41.93Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/f2/c54f33c92443d087703e57e52e55f22f111373a5c4c4aa349ea60efe512e/opentelemetry_exporter_otlp_proto_grpc-1.41.1-py3-none-any.whl", hash = "sha256:537926dcef951136992479af1d9cd88f25e33d56c530e9f020ed57774dca2f94", size = 20297, upload-time = "2026-04-24T13:15:20.212Z" },
-]
-
-[[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
@@ -746,7 +697,6 @@ dependencies = [
     { name = "chatlas" },
     { name = "click" },
     { name = "duckdb" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
@@ -770,7 +720,6 @@ requires-dist = [
     { name = "chatlas", specifier = ">=0.16.0" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "duckdb", specifier = ">=1.5.2" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.41.1" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.41.1" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.62b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.41.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -606,6 +606,24 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
@@ -729,6 +747,7 @@ dependencies = [
     { name = "click" },
     { name = "duckdb" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
     { name = "polars" },
@@ -752,6 +771,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "duckdb", specifier = ">=1.5.2" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.41.1" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.41.1" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.62b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.41.1" },
     { name = "polars", specifier = ">=1.40.1" },


### PR DESCRIPTION
## Summary

Adds an OpenTelemetry telemetry module that instruments all seven agent tools with spans, counters, and latency histograms. When no OTLP endpoint is configured the module is a complete no-op with zero runtime overhead.

## Changes

- Add `telemetry.py` with `setup()` and `instrument_tool()` — initialises OTLP HTTP exporters for traces (Tempo), metrics (Mimir), and logs (Loki) when an endpoint is provided
- Wrap all seven agent tools in `instrument_tool()` in `agent.py`, recording tool name, call arguments, and duration as span attributes
- Add metric counters for packets ingested, queries run, and anomalies detected; add a per-tool call latency histogram
- Wire the existing `--otlp-endpoint` CLI flag to `telemetry.setup()` before the agent is created
- Add `grafana-up` / `grafana-down` Justfile targets for a local `grafana/otel-lgtm` stack (Grafana on :3000, OTLP HTTP on :4318)
- Fix: move `record_queries_run()` inside the try block so failed SQL executions are not counted
- Remove unused `opentelemetry-exporter-otlp-proto-grpc` dependency (all exporters use HTTP equivalents, saving the `grpcio` native binary)

## Testing

253 tests pass (`uv run pytest`). The telemetry test suite (`tests/test_telemetry.py`) uses `InMemorySpanExporter` and `InMemoryMetricReader` to verify spans, attributes, and metric counters without a running collector.

To test against a real backend:

```bash
just grafana-up   # starts grafana/otel-lgtm at localhost:3000
just run-repl --otlp-endpoint http://localhost:4318 path/to/file.pcap
# open Grafana at http://localhost:3000 to inspect traces and metrics
just grafana-down
```

> **Note — Loki (logs) will be empty**: The log bridge (`LoggingInstrumentor`) is wired up, but the codebase does not yet use Python's `logging` module. No log records are emitted, so nothing appears in Loki. Adding `logging` calls to the tool functions is tracked in a follow-up issue.

## Related Issues

Closes #9
