### PR TITLE
feat(cli,config,telemetry): replace --verbose with --log-level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ tests/
 - **Tools return plain dicts** so the agent can serialize and reason about results.
 - **Expected errors return structured dicts** `{"error": ..., "hint": ...}`; unexpected exceptions propagate. This lets the agent self-correct on bad input without crashing.
 - **`ingest_pcap` closes the previous connection** when switching to a different DB file (DuckDB single-writer constraint). Any fixture or caller that holds a reference to the old connection object must re-open by path, not restore the closed handle.
-- **Telemetry is a no-op by default** (`telemetry.py`): `setup("")` skips all OTel SDK initialisation. All 7 tools are wrapped with `instrument_tool()` in `agent.py`; spans and metrics are only emitted when an OTLP endpoint is configured. Metric counters (`record_packets_ingested`, `record_queries_run`, `record_anomalies_detected`) live in the tool functions themselves so the CLI initial ingest also records metrics.
+- **Telemetry is a no-op by default** (`telemetry.py`): `setup(endpoint, log_level)` always configures the root logger via `logging.basicConfig(..., force=True)`, then returns early if `endpoint` is empty (skipping all OTel SDK initialisation). All 7 tools are wrapped with `instrument_tool()` in `agent.py`; spans and metrics are only emitted when an OTLP endpoint is configured. Metric counters (`record_packets_ingested`, `record_queries_run`, `record_anomalies_detected`) live in the tool functions themselves so the CLI initial ingest also records metrics.
 
 ## Schema
 
@@ -97,6 +97,9 @@ Use `InMemorySpanExporter` and `InMemoryMetricReader` from the OTel SDK to unit-
 
 To patch multiple OTel symbols inside a function that does lazy imports (e.g. `setup()`), use `contextlib.ExitStack` — Python's `with` statement does not support `*`-unpacking a list of context managers.
 
+### Root logger level in tests
+`telemetry.setup()` configures the root logger via `logging.basicConfig(..., force=True)`, which always replaces existing handlers. Tests that call `setup()` with a non-default level must restore `logging.getLogger().level` (and handlers) in a `try/finally` block, because the `reset_telemetry` autouse fixture does not reset root logger state.
+
 ### Test file ordering matters
 pytest collects files alphabetically. Tests in `test_query_tool.py` run after `test_ingest.py::TestIngestCaching`, which temporarily replaces the session connection. The `_restore_state` fixture must leave `_state._conn` in a valid open state or later test files will see a closed connection.
 
@@ -108,7 +111,7 @@ pytest collects files alphabetically. Tests in `test_query_tool.py` run after `t
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | Model to use |
 | `PCAP_AGENT_DB_DIR` | `~/.cache/pcap-agent` | Where DuckDB files are stored |
 | `PCAP_AGENT_UI` | `console` | UI mode |
-| `PCAP_AGENT_VERBOSE` | `""` | Enable verbose logging |
+| `PCAP_AGENT_LOG_LEVEL` | `WARNING` | Root logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | OpenTelemetry OTLP endpoint |
 
 Tests set `ANTHROPIC_API_KEY=test-dummy-key` via `pytest_configure` in `conftest.py`.

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -43,10 +43,12 @@ import click
     help="OpenTelemetry OTLP exporter endpoint [env: OTEL_EXPORTER_OTLP_ENDPOINT]",
 )
 @click.option(
-    "--verbose",
-    is_flag=True,
-    default=False,
-    help="Enable verbose logging [env: PCAP_AGENT_VERBOSE]",
+    "--log-level",
+    envvar="PCAP_AGENT_LOG_LEVEL",
+    default="WARNING",
+    show_default=True,
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    help="Logging level [env: PCAP_AGENT_LOG_LEVEL]",
 )
 def main(
     pcap_file: str | None,
@@ -55,14 +57,12 @@ def main(
     ui: str,
     db_dir: str,
     otlp_endpoint: str,
-    verbose: bool,
+    log_level: str,
 ) -> None:
     """PCAP analysis agent powered by Claude.
 
     Optionally provide a PCAP_FILE to ingest before starting the chat session.
     """
-    verbose = verbose or bool(os.environ.get("PCAP_AGENT_VERBOSE", ""))
-
     if not api_key:
         click.echo(
             "Error: ANTHROPIC_API_KEY is not set. "
@@ -80,11 +80,11 @@ def main(
     os.environ["PCAP_AGENT_UI"] = ui
     os.environ["PCAP_AGENT_DB_DIR"] = db_dir_expanded
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint
-    os.environ["PCAP_AGENT_VERBOSE"] = "1" if verbose else ""
+    os.environ["PCAP_AGENT_LOG_LEVEL"] = log_level
 
     from pcap_agent import telemetry
 
-    telemetry.setup(otlp_endpoint, verbose)
+    telemetry.setup(otlp_endpoint, log_level)
 
     if pcap_file:
         from rich.progress import Progress, SpinnerColumn, TextColumn

--- a/src/pcap_agent/config.py
+++ b/src/pcap_agent/config.py
@@ -18,12 +18,21 @@ class Config:
     pcap_agent_log_level: str
 
 
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
 def _load() -> Config:
     api_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if not api_key:
         raise ValueError(
             "ANTHROPIC_API_KEY is not set. "
             "Provide it in your environment or .env file."
+        )
+    log_level = os.environ.get("PCAP_AGENT_LOG_LEVEL", "WARNING").upper()
+    if log_level not in _VALID_LOG_LEVELS:
+        raise ValueError(
+            f"PCAP_AGENT_LOG_LEVEL must be one of {sorted(_VALID_LOG_LEVELS)}, "
+            f"got {log_level!r}"
         )
     return Config(
         anthropic_api_key=api_key,
@@ -33,7 +42,7 @@ def _load() -> Config:
             os.environ.get("PCAP_AGENT_DB_DIR", "~/.cache/pcap-agent")
         ),
         otel_exporter_otlp_endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
-        pcap_agent_log_level=os.environ.get("PCAP_AGENT_LOG_LEVEL", "WARNING"),
+        pcap_agent_log_level=log_level,
     )
 
 

--- a/src/pcap_agent/config.py
+++ b/src/pcap_agent/config.py
@@ -15,7 +15,7 @@ class Config:
     pcap_agent_ui: str
     pcap_agent_db_dir: str
     otel_exporter_otlp_endpoint: str
-    pcap_agent_verbose: bool
+    pcap_agent_log_level: str
 
 
 def _load() -> Config:
@@ -33,8 +33,7 @@ def _load() -> Config:
             os.environ.get("PCAP_AGENT_DB_DIR", "~/.cache/pcap-agent")
         ),
         otel_exporter_otlp_endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
-        pcap_agent_verbose=os.environ.get("PCAP_AGENT_VERBOSE", "").lower()
-        in ("1", "true", "yes"),
+        pcap_agent_log_level=os.environ.get("PCAP_AGENT_LOG_LEVEL", "WARNING"),
     )
 
 

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import functools
 import inspect
+import logging
+import sys
 import time
 from typing import Any, Callable
 
@@ -12,9 +14,16 @@ _meter: Any = None
 _metrics: dict[str, Any] = {}
 
 
-def setup(endpoint: str = "", verbose: bool = False) -> None:
+def setup(endpoint: str = "", log_level: str = "WARNING") -> None:
     """Initialize OTel SDK with OTLP HTTP exporters. No-op if endpoint is empty."""
     global _tracer, _meter, _metrics
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=log_level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    logging.getLogger().setLevel(log_level)
 
     if not endpoint:
         return
@@ -79,7 +88,7 @@ def setup(endpoint: str = "", verbose: bool = False) -> None:
         BatchLogRecordProcessor(OTLPLogExporter(endpoint=f"{base}/v1/logs"))
     )
     set_logger_provider(lp)
-    LoggingInstrumentor().instrument(set_logging_format=verbose)
+    LoggingInstrumentor().instrument()
 
 
 def instrument_tool(func: Callable) -> Callable:

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -22,8 +22,8 @@ def setup(endpoint: str = "", log_level: str = "WARNING") -> None:
         stream=sys.stderr,
         level=log_level,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        force=True,
     )
-    logging.getLogger().setLevel(log_level)
 
     if not endpoint:
         return

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -87,6 +88,15 @@ class TestSetupNoOp:
 
     def test_empty_endpoint_does_not_raise(self):
         telemetry.setup("")
+
+    def test_no_endpoint_sets_root_logger_level(self):
+        root = logging.getLogger()
+        original_level = root.level
+        try:
+            telemetry.setup("", log_level="DEBUG")
+            assert root.level == logging.DEBUG
+        finally:
+            root.setLevel(original_level)
 
 
 class TestSetupWithEndpoint:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -71,6 +71,15 @@ def _get_histogram_count(metric_reader, name: str) -> int:
 
 
 class TestSetupNoOp:
+    @pytest.fixture(autouse=True)
+    def restore_root_logger(self):
+        root = logging.getLogger()
+        original_level = root.level
+        original_handlers = root.handlers[:]
+        yield
+        root.handlers[:] = original_handlers
+        root.setLevel(original_level)
+
     def test_empty_endpoint_leaves_tracer_none(self):
         telemetry.setup("")
         assert telemetry._tracer is None
@@ -90,15 +99,8 @@ class TestSetupNoOp:
         telemetry.setup("")
 
     def test_no_endpoint_sets_root_logger_level(self):
-        root = logging.getLogger()
-        original_level = root.level
-        original_handlers = root.handlers[:]
-        try:
-            telemetry.setup("", log_level="DEBUG")
-            assert root.level == logging.DEBUG
-        finally:
-            root.handlers[:] = original_handlers
-            root.setLevel(original_level)
+        telemetry.setup("", log_level="DEBUG")
+        assert logging.getLogger().level == logging.DEBUG
 
 
 class TestSetupWithEndpoint:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -92,10 +92,12 @@ class TestSetupNoOp:
     def test_no_endpoint_sets_root_logger_level(self):
         root = logging.getLogger()
         original_level = root.level
+        original_handlers = root.handlers[:]
         try:
             telemetry.setup("", log_level="DEBUG")
             assert root.level == logging.DEBUG
         finally:
+            root.handlers[:] = original_handlers
             root.setLevel(original_level)
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -18,6 +18,17 @@ def reset_telemetry():
     telemetry._reset()
 
 
+@pytest.fixture(autouse=True)
+def restore_root_logger():
+    """Restore root logger handlers and level after each test."""
+    root = logging.getLogger()
+    original_level = root.level
+    original_handlers = root.handlers[:]
+    yield
+    root.handlers[:] = original_handlers
+    root.setLevel(original_level)
+
+
 @pytest.fixture()
 def memory_telemetry():
     """Configure telemetry with in-memory OTel exporters (no real OTLP server)."""
@@ -71,15 +82,6 @@ def _get_histogram_count(metric_reader, name: str) -> int:
 
 
 class TestSetupNoOp:
-    @pytest.fixture(autouse=True)
-    def restore_root_logger(self):
-        root = logging.getLogger()
-        original_level = root.level
-        original_handlers = root.handlers[:]
-        yield
-        root.handlers[:] = original_handlers
-        root.setLevel(original_level)
-
     def test_empty_endpoint_leaves_tracer_none(self):
         telemetry.setup("")
         assert telemetry._tracer is None


### PR DESCRIPTION
## Summary

Replace the boolean `--verbose` flag and `PCAP_AGENT_VERBOSE` env var with a
`--log-level` flag and `PCAP_AGENT_LOG_LEVEL` env var. The new flag accepts
`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (default: `WARNING`) and
configures Python's root logger unconditionally via `logging.basicConfig`, so
logging works with or without an OTLP endpoint.

## Changes

- Remove `--verbose` / `PCAP_AGENT_VERBOSE` from the CLI and `Config`
- Add `--log-level` / `PCAP_AGENT_LOG_LEVEL` with `click.Choice` validation and `WARNING` default
- Replace `pcap_agent_verbose: bool` with `pcap_agent_log_level: str` in `Config`; validate against allowed levels at load time with a descriptive `ValueError` for invalid values
- Update `telemetry.setup()` signature from `(endpoint, verbose)` to `(endpoint, log_level)`; call `logging.basicConfig(..., force=True)` unconditionally before the OTLP no-op guard
- Drop `set_logging_format` from `LoggingInstrumentor`
- Add `restore_root_logger` module-level `autouse` fixture to `test_telemetry.py` so `basicConfig(force=True)` does not evict pytest's log-capture handler across test classes
- Add test verifying `setup("", log_level="DEBUG")` sets root logger level to `DEBUG`

## Testing

```bash
uv run pytest          # 138 tests pass
uv run ruff check src tests
```

## Related Issues

Closes #19
