### PR TITLE
feat(logging): add structured logging to parse and ingest pipeline

### DIFF
--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import duckdb
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pcap_agent.parser import ParsedPcap
@@ -54,6 +57,7 @@ CREATE TABLE IF NOT EXISTS pcap_meta (
 
 def create_schema(conn: duckdb.DuckDBPyConnection) -> None:
     """Create all normalized tables and the pcap_meta cache table."""
+    logger.debug("Creating database schema")
     conn.execute(_DDL)
 
 
@@ -118,5 +122,7 @@ def get_cached(
         [sha256],
     ).fetchone()
     if row is None:
+        logger.debug("Cache miss for sha256=%s", sha256)
         return None
+    logger.debug("Cache hit for sha256=%s path=%s", sha256, row[1])
     return {"sha256": row[0], "pcap_path": row[1], "ingested_at": row[2]}

--- a/src/pcap_agent/parser.py
+++ b/src/pcap_agent/parser.py
@@ -1,10 +1,13 @@
 """Parse a PCAP file into normalized polars DataFrames using scapy."""
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
 import polars as pl
 from scapy.all import ICMP, IP, TCP, UDP, rdpcap  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
 
 _PROTO_TCP = 6
 _PROTO_UDP = 17
@@ -55,6 +58,7 @@ class ParsedPcap:
 
 def parse(pcap_path: Path | str) -> ParsedPcap:
     """Parse a PCAP file and return four normalized DataFrames."""
+    logger.info("Parsing PCAP file: %s", pcap_path)
     raw_packets = rdpcap(str(pcap_path))
 
     packets_rows: list[dict] = []
@@ -121,6 +125,14 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
             )
 
         packet_id += 1
+
+    logger.info("Parsed %d IP packets from %s", len(packets_rows), pcap_path)
+    logger.debug(
+        "Protocol breakdown — TCP: %d, UDP: %d, ICMP: %d",
+        len(tcp_rows),
+        len(udp_rows),
+        len(icmp_rows),
+    )
 
     return ParsedPcap(
         packets=pl.DataFrame(packets_rows, schema=_PACKETS_SCHEMA)

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -28,6 +28,8 @@ def setup(endpoint: str = "", log_level: str = "WARNING") -> None:
     if not endpoint:
         return
 
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     from opentelemetry import metrics as otel_metrics
     from opentelemetry import trace
     from opentelemetry._logs import set_logger_provider

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -1,6 +1,7 @@
 """Ingest tool: parse and persist a PCAP file, auto-run analysis."""
 
 import hashlib
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,8 @@ from pcap_agent.config import config
 from pcap_agent.tools import _state
 from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
 
+logger = logging.getLogger(__name__)
+
 
 def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     """Ingest a PCAP file into DuckDB and return a summary dict.
@@ -20,6 +23,7 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     protocol breakdown and top-talker analysis.
     """
     pcap_path = Path(path)
+    logger.info("Starting ingest for %s", pcap_path)
     sha256 = _sha256(pcap_path)
 
     effective_db_dir = db_dir or config.pcap_agent_db_dir
@@ -44,6 +48,11 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
             old_conn.close()
 
     if db.get_cached(conn, sha256) is not None:
+        logger.warning(
+            "File already cached (sha256=%s path=%s), skipping ingest",
+            sha256,
+            pcap_path,
+        )
         return _summary(conn, sha256, db_path, cached=True)
 
     frames = parser.parse(pcap_path)
@@ -69,6 +78,7 @@ def _summary(
     n_packets = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
     if not cached:
         telemetry.record_packets_ingested(n_packets)
+        logger.info("Ingest complete: %d packets stored in %s", n_packets, db_path)
     row = conn.execute(
         "SELECT MIN(timestamp), MAX(timestamp) FROM packets"
     ).fetchone()


### PR DESCRIPTION
## Summary

Add `logging.getLogger(__name__)` and meaningful log calls to `parser.py`,
`db.py`, and `tools/ingest.py`. Running with `--log-level INFO` now produces
visible terminal output covering the full parse-to-persist path, and emits
to Grafana when an OTLP endpoint is configured.

## Changes

- `parser.py`: INFO on parse start and finish (file path, IP packet count);
  DEBUG for per-protocol row counts (TCP, UDP, ICMP)
- `db.py`: DEBUG when `create_schema` is called; DEBUG for cache hit and
  miss in `get_cached`
- `tools/ingest.py`: INFO when ingest begins (pcap path) and completes
  (packet count, db path); WARNING when a file is already cached and ingest
  is skipped

## Testing

All 138 existing tests pass (`uv run pytest`). No new log output appears at
the default `WARNING` level during a normal ingest.

## Related Issues

Closes #20
