### PR TITLE
feat(logging): add structured logging to agent, analysis, and query tools

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -1,5 +1,7 @@
 """Agent: chatlas session wired with all PCAP analysis tools."""
 
+import logging
+
 from chatlas import ChatAnthropic
 
 from pcap_agent import telemetry
@@ -8,6 +10,8 @@ from pcap_agent.tools.detection import detect_anomalies, detect_port_scans
 from pcap_agent.tools.ingest import ingest_pcap
 from pcap_agent.tools.query import query
 from pcap_agent.tools.reassembly import reassemble_stream
+
+logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = """\
 You are a terse, experienced network security analyst.
@@ -30,11 +34,17 @@ def create_agent(*, api_key: str, model: str) -> "ChatAnthropic":
         model=model,
         api_key=api_key,
     )
-    chat.register_tool(telemetry.instrument_tool(ingest_pcap))
-    chat.register_tool(telemetry.instrument_tool(get_protocol_breakdown))
-    chat.register_tool(telemetry.instrument_tool(get_top_talkers))
-    chat.register_tool(telemetry.instrument_tool(query))
-    chat.register_tool(telemetry.instrument_tool(detect_port_scans))
-    chat.register_tool(telemetry.instrument_tool(detect_anomalies))
-    chat.register_tool(telemetry.instrument_tool(reassemble_stream))
+    logger.info("Agent session started (model=%s)", model)
+    _tools = [
+        ingest_pcap,
+        get_protocol_breakdown,
+        get_top_talkers,
+        query,
+        detect_port_scans,
+        detect_anomalies,
+        reassemble_stream,
+    ]
+    for tool in _tools:
+        chat.register_tool(telemetry.instrument_tool(tool))
+        logger.debug("Registered tool: %s", tool.__name__)
     return chat

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -159,3 +159,4 @@ def _reset() -> None:
     _tracer = None
     _meter = None
     _metrics = {}
+    logging.getLogger("urllib3").setLevel(logging.NOTSET)

--- a/src/pcap_agent/tools/analysis.py
+++ b/src/pcap_agent/tools/analysis.py
@@ -1,6 +1,10 @@
 """Read-only analysis tools: protocol breakdown and top talkers."""
 
+import logging
+
 from pcap_agent.tools import _state
+
+logger = logging.getLogger(__name__)
 
 _PROTO_MAP = {1: "ICMP", 6: "TCP", 17: "UDP"}
 
@@ -23,6 +27,7 @@ def get_protocol_breakdown() -> list[dict]:
             name = "unknown"
         pct = round(count / total * 100, 1) if total else 0.0
         result.append({"protocol": name, "count": count, "pct": pct})
+    logger.debug("get_protocol_breakdown returned %d protocol(s)", len(result))
     return result
 
 
@@ -39,4 +44,6 @@ def get_top_talkers(n: int = 10) -> list[dict]:
         "LIMIT ?",
         [n],
     ).fetchall()
-    return [{"src_ip": r[0], "packet_count": r[1]} for r in rows]
+    result = [{"src_ip": r[0], "packet_count": r[1]} for r in rows]
+    logger.debug("get_top_talkers(n=%d) returned %d result(s)", n, len(result))
+    return result

--- a/src/pcap_agent/tools/query.py
+++ b/src/pcap_agent/tools/query.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -9,6 +10,8 @@ import duckdb
 
 from pcap_agent import telemetry
 from pcap_agent.tools import _state
+
+logger = logging.getLogger(__name__)
 
 _MAX_ROWS = 500
 
@@ -35,17 +38,20 @@ def query(sql: str) -> dict[str, Any]:
     """
     if not _ALLOWED_STMT_RE.match(sql):
         stmt_type = sql.strip().split()[0].upper() if sql.strip() else "(empty)"
+        logger.warning("Rejected statement type: %s", stmt_type)
         return {
             "error": f"Statement type '{stmt_type}' is not allowed.",
             "hint": "Only SELECT and CREATE TEMP VIEW statements are permitted.",
         }
 
     conn = _state.require_connection()
+    logger.debug("Executing SQL: %s", sql)
 
     try:
         relation = conn.execute(sql)
         telemetry.record_queries_run()
     except duckdb.Error as exc:
+        logger.error("DuckDB error: %s", exc)
         return {
             "error": str(exc),
             "hint": "Check your SQL syntax and column/table names.",
@@ -62,8 +68,10 @@ def query(sql: str) -> dict[str, Any]:
     truncated = len(fetched) > _MAX_ROWS
     rows = fetched[:_MAX_ROWS]
 
+    row_count = len(rows)
+    logger.info("Query returned %d row(s)", row_count)
     return {
         "rows": [dict(zip(columns, row)) for row in rows],
         "truncated": truncated,
-        "row_count": len(rows),
+        "row_count": row_count,
     }

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -51,7 +51,10 @@ class TestAgentLogging:
         with caplog.at_level(logging.DEBUG, logger="pcap_agent.agent"):
             create_agent(api_key="test-dummy-key", model="test-model")
 
-        debug_msgs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        debug_msgs = [
+            r for r in caplog.records
+            if r.levelno == logging.DEBUG and r.name == "pcap_agent.agent"
+        ]
         assert len(debug_msgs) == 7
 
     def test_logger_uses_module_name(self):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,136 @@
+"""Tests verifying structured logging in agent.py, analysis.py, and query.py."""
+
+import logging
+
+import pytest
+
+from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
+from pcap_agent.tools.query import query
+
+
+class TestAgentLogging:
+    def test_session_start_logged_at_info(self, caplog):
+        from pcap_agent.agent import create_agent
+
+        with caplog.at_level(logging.INFO, logger="pcap_agent.agent"):
+            create_agent(api_key="test-dummy-key", model="test-model")
+
+        info_msgs = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("test-model" in r.message for r in info_msgs)
+
+    def test_session_start_not_logged_at_warning(self, caplog):
+        from pcap_agent.agent import create_agent
+
+        with caplog.at_level(logging.WARNING, logger="pcap_agent.agent"):
+            create_agent(api_key="test-dummy-key", model="test-model")
+
+        assert not any("test-model" in r.message for r in caplog.records)
+
+    def test_tool_registrations_logged_at_debug(self, caplog):
+        from pcap_agent.agent import create_agent
+
+        with caplog.at_level(logging.DEBUG, logger="pcap_agent.agent"):
+            create_agent(api_key="test-dummy-key", model="test-model")
+
+        debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        expected_tools = [
+            "ingest_pcap",
+            "get_protocol_breakdown",
+            "get_top_talkers",
+            "query",
+            "detect_port_scans",
+            "detect_anomalies",
+            "reassemble_stream",
+        ]
+        for tool_name in expected_tools:
+            assert any(tool_name in msg for msg in debug_msgs)
+
+    def test_seven_tool_registrations_logged(self, caplog):
+        from pcap_agent.agent import create_agent
+
+        with caplog.at_level(logging.DEBUG, logger="pcap_agent.agent"):
+            create_agent(api_key="test-dummy-key", model="test-model")
+
+        debug_msgs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(debug_msgs) == 7
+
+    def test_logger_uses_module_name(self):
+        import pcap_agent.agent as agent_mod
+
+        assert agent_mod.logger.name == "pcap_agent.agent"
+
+
+class TestAnalysisLogging:
+    def test_protocol_breakdown_logged_at_debug(self, ingested_db, caplog):
+        with caplog.at_level(logging.DEBUG, logger="pcap_agent.tools.analysis"):
+            result = get_protocol_breakdown()
+
+        debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(str(len(result)) in msg for msg in debug_msgs)
+
+    def test_protocol_breakdown_not_logged_at_warning(self, ingested_db, caplog):
+        with caplog.at_level(logging.WARNING, logger="pcap_agent.tools.analysis"):
+            get_protocol_breakdown()
+
+        assert not caplog.records
+
+    def test_top_talkers_logged_at_debug(self, ingested_db, caplog):
+        with caplog.at_level(logging.DEBUG, logger="pcap_agent.tools.analysis"):
+            result = get_top_talkers(3)
+
+        debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("3" in msg for msg in debug_msgs)
+        assert any(str(len(result)) in msg for msg in debug_msgs)
+
+    def test_top_talkers_not_logged_at_warning(self, ingested_db, caplog):
+        with caplog.at_level(logging.WARNING, logger="pcap_agent.tools.analysis"):
+            get_top_talkers(5)
+
+        assert not caplog.records
+
+    def test_logger_uses_module_name(self):
+        import pcap_agent.tools.analysis as analysis_mod
+
+        assert analysis_mod.logger.name == "pcap_agent.tools.analysis"
+
+
+class TestQueryLogging:
+    def test_sql_logged_at_debug(self, ingested_db, caplog):
+        sql = "SELECT src_ip FROM packets LIMIT 1"
+        with caplog.at_level(logging.DEBUG, logger="pcap_agent.tools.query"):
+            query(sql)
+
+        debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(sql in msg for msg in debug_msgs)
+
+    def test_row_count_logged_at_info(self, ingested_db, caplog):
+        with caplog.at_level(logging.INFO, logger="pcap_agent.tools.query"):
+            result = query("SELECT src_ip FROM packets LIMIT 5")
+
+        info_msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
+        assert any(str(result["row_count"]) in msg for msg in info_msgs)
+
+    def test_row_count_not_logged_at_warning(self, ingested_db, caplog):
+        with caplog.at_level(logging.WARNING, logger="pcap_agent.tools.query"):
+            query("SELECT src_ip FROM packets LIMIT 5")
+
+        assert not caplog.records
+
+    def test_rejected_statement_logged_at_warning(self, ingested_db, caplog):
+        with caplog.at_level(logging.WARNING, logger="pcap_agent.tools.query"):
+            query("DROP TABLE packets")
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("DROP" in msg for msg in warning_msgs)
+
+    def test_duckdb_error_logged_at_error(self, ingested_db, caplog):
+        with caplog.at_level(logging.ERROR, logger="pcap_agent.tools.query"):
+            query("SELECT FROM WHERE")
+
+        error_msgs = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_msgs) >= 1
+
+    def test_logger_uses_module_name(self):
+        import pcap_agent.tools.query as query_mod
+
+        assert query_mod.logger.name == "pcap_agent.tools.query"


### PR DESCRIPTION
## Summary

Adds `logging.getLogger(__name__)` loggers to `agent.py`, `tools/analysis.py`, and `tools/query.py`. Running with `--log-level DEBUG` now reveals session startup, every tool registration, every analysis call with result summaries, and every SQL statement submitted. Normal query and analysis operations produce no output at the default `WARNING` level.

Also fixes a test-isolation bug in `telemetry._reset()` where the urllib3 logger level clamped by `setup()` was never restored.

## Changes

- `agent.py`: logs INFO on session start (with model name); logs DEBUG for each of the 7 tool registrations
- `tools/analysis.py`: logs DEBUG after each `get_protocol_breakdown` call (protocol count) and each `get_top_talkers` call (`n` and result count)
- `tools/query.py`: logs DEBUG with the full SQL before execution; INFO with row count on success; WARNING with the rejected statement type; ERROR with the exception message on `duckdb.Error`
- `telemetry.py`: `_reset()` now calls `logging.getLogger("urllib3").setLevel(logging.NOTSET)` to undo the WARNING clamp applied when an OTLP endpoint is configured
- `tests/test_logging.py`: 16 new tests covering all log levels, logger names, and the no-output-at-WARNING guarantee

## Testing

```bash
uv run pytest tests/test_logging.py -v
uv run pytest  # full suite — 154 tests pass
```

## Related Issues

Closes #21
