### PR TITLE
feat(logging): add logging to detection and reassembly tools

### DIFF
--- a/src/pcap_agent/tools/detection.py
+++ b/src/pcap_agent/tools/detection.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from sklearn.ensemble import IsolationForest
 
 from pcap_agent import telemetry
 from pcap_agent.tools import _state
+
+logger = logging.getLogger(__name__)
 
 _PORT_SCAN_SQL = """
 WITH port_contacts AS (
@@ -71,6 +75,7 @@ def detect_port_scans(threshold: int = 10) -> list[dict] | dict:
             "hint": "Use threshold >= 1",
         }
 
+    logger.debug("detect_port_scans: threshold=%d", threshold)
     conn = _state.require_connection()
     rows = conn.execute(_PORT_SCAN_SQL).fetchall()
 
@@ -90,6 +95,8 @@ def detect_port_scans(threshold: int = 10) -> list[dict] | dict:
                 "classification": classification,
             }
         )
+    suspicious_count = sum(1 for r in result if r["classification"] == "Suspicious")
+    logger.info("detect_port_scans: found %d suspicious IP(s)", suspicious_count)
     return result
 
 
@@ -105,6 +112,7 @@ def detect_anomalies(contamination: float = 0.02) -> list[dict] | dict:
             "hint": "Try contamination=0.02",
         }
 
+    logger.debug("detect_anomalies: contamination=%s", contamination)
     conn = _state.require_connection()
     rows = conn.execute(_ANOMALY_SQL).fetchall()
 
@@ -132,5 +140,6 @@ def detect_anomalies(contamination: float = 0.02) -> list[dict] | dict:
         for rec, label, score in zip(records, labels, scores)
         if label == -1
     ]
+    logger.info("detect_anomalies: flagged %d anomalous packet(s)", len(anomalies))
     telemetry.record_anomalies_detected(len(anomalies))
     return anomalies

--- a/src/pcap_agent/tools/reassembly.py
+++ b/src/pcap_agent/tools/reassembly.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 from pcap_agent.tools import _state
+
+logger = logging.getLogger(__name__)
 
 _MAX_BYTES = 64 * 1024  # 64 KB
 
@@ -27,6 +31,10 @@ def reassemble_stream(
             "hint": "Use 'TCP' or 'UDP'.",
         }
 
+    logger.debug(
+        "reassemble_stream: src_ip=%s dst_ip=%s src_port=%d dst_port=%d protocol=%s",
+        src_ip, dst_ip, src_port, dst_port, proto,
+    )
     conn = _state.require_connection()
     proto_num = 6 if proto == "TCP" else 17
 
@@ -81,6 +89,9 @@ def reassemble_stream(
             chunks.append(chunk[:remaining])
             total += remaining
             truncated = True
+            logger.warning(
+                "reassemble_stream: 64 KB cap reached, stream truncated"
+            )
             break
         chunks.append(chunk)
         total += len(chunk)
@@ -93,6 +104,9 @@ def reassemble_stream(
         text = raw.hex()
         encoding = "hex"
 
+    logger.info(
+        "reassemble_stream: reassembled %d byte(s), encoding=%s", total, encoding
+    )
     return {
         "src_ip": src_ip,
         "dst_ip": dst_ip,


### PR DESCRIPTION
## Summary

Adds structured logging to `tools/detection.py` and `tools/reassembly.py`,
completing logging coverage across all seven agent tools.

## Changes

- `detection.py`: DEBUG log for threshold before `detect_port_scans`; INFO log
  for count of Suspicious-classified IPs after
- `detection.py`: DEBUG log for contamination before `detect_anomalies`; INFO
  log for anomaly count after
- `reassembly.py`: DEBUG log for the stream 5-tuple at entry; INFO log for
  bytes reassembled and encoding on success; WARNING log when the 64 KB cap is
  hit and the stream is truncated
- All loggers use `logging.getLogger(__name__)`

## Testing

All 154 existing tests pass (`uv run pytest`). No WARNING output is produced at
the default log level for normal operations — only the 64 KB truncation path
emits a WARNING.

## Related Issues

Closes #22
