### PR TITLE
fix(agent,cli): agent unaware of pre-ingested file; no synopsis shown on load

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -26,11 +26,20 @@ call ingest_pcap before answering.
 - Do not explain what the tools do unless asked.
 """
 
+_PCAP_LOADED_SUFFIX = "\nA PCAP file has already been ingested: `{pcap_file}`. \
+The data is ready for analysis."
 
-def create_agent(*, api_key: str, model: str) -> "ChatAnthropic":
+
+def create_agent(
+    *, api_key: str, model: str, pcap_file: str | None = None
+) -> "ChatAnthropic":
     """Return a ChatAnthropic session with all 7 analysis tools registered."""
+    system_prompt = _SYSTEM_PROMPT
+    if pcap_file:
+        system_prompt += _PCAP_LOADED_SUFFIX.format(pcap_file=pcap_file)
+
     chat = ChatAnthropic(
-        system_prompt=_SYSTEM_PROMPT,
+        system_prompt=system_prompt,
         model=model,
         api_key=api_key,
     )

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -2,8 +2,31 @@
 
 import os
 import sys
+from pathlib import Path
+from typing import Any
 
 import click
+
+
+def _print_synopsis(pcap_file: str, result: dict[str, Any]) -> None:
+    label = "(from cache)" if result.get("cached") else "(new)"
+    click.echo(
+        f"\nLoaded {Path(pcap_file).name} {label} — {result['n_packets']} packets"
+    )
+
+    protocols = result.get("protocol_counts", [])
+    if protocols:
+        parts = ", ".join(
+            f"{p['protocol']} {p['pct']}%" for p in protocols
+        )
+        click.echo(f"  Protocols: {parts}")
+
+    talkers = result.get("top_talkers", [])
+    if talkers:
+        top = talkers[0]
+        click.echo(
+            f"  Top talker: {top['src_ip']} ({top['packet_count']} packets)"
+        )
 
 
 @click.command()
@@ -100,6 +123,8 @@ def main(
             result = ingest_pcap(pcap_file, db_dir=db_dir_expanded)
         if not result.get("n_packets"):
             click.echo("Warning: no packets were ingested from the file.", err=True)
+        else:
+            _print_synopsis(pcap_file, result)
 
     from pcap_agent.agent import create_agent
 

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -103,7 +103,7 @@ def main(
 
     from pcap_agent.agent import create_agent
 
-    chat = create_agent(api_key=api_key, model=model)
+    chat = create_agent(api_key=api_key, model=model, pcap_file=pcap_file)
 
     if ui == "app":
         chat.app()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,17 @@
+"""Tests for agent creation and system prompt construction."""
+
+from pcap_agent.agent import create_agent
+
+
+class TestCreateAgent:
+    def test_system_prompt_contains_pcap_path_when_provided(self):
+        chat = create_agent(
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            pcap_file="/data/evidence01.pcap",
+        )
+        assert "/data/evidence01.pcap" in chat.system_prompt
+
+    def test_system_prompt_no_file_context_when_not_provided(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        assert "already ingested" not in chat.system_prompt

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,88 @@
+"""Tests for the CLI entry point."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from constants import TOTAL_FRAMES, UDP_TOP_TALKER_IP
+
+from pcap_agent.cli import main
+
+
+@pytest.fixture()
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def mock_chat():
+    chat = MagicMock()
+    chat.console.return_value = None
+    return chat
+
+
+class TestCliSynopsis:
+    """CLI prints a synopsis after loading a PCAP, new or cached."""
+
+    def _invoke(self, cli_runner, mock_chat, pcap_path, db_dir):
+        with patch("pcap_agent.agent.create_agent", return_value=mock_chat):
+            return cli_runner.invoke(
+                main,
+                [
+                    str(pcap_path),
+                    "--api-key",
+                    "test-key",
+                    "--db-dir",
+                    db_dir,
+                    "--ui",
+                    "console",
+                ],
+                catch_exceptions=False,
+            )
+
+    def test_new_file_synopsis_shows_packet_count(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        assert result.exit_code == 0, result.output
+        assert str(TOTAL_FRAMES) in result.output
+
+    def test_new_file_synopsis_shows_protocol(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        assert result.exit_code == 0, result.output
+        assert "UDP" in result.output or "TCP" in result.output
+
+    def test_new_file_synopsis_shows_top_talker(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        assert result.exit_code == 0, result.output
+        assert UDP_TOP_TALKER_IP in result.output
+
+    def test_cached_file_synopsis_shows_packet_count(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        # First invocation — ingests the file
+        self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        # Second invocation — cache hit; synopsis must still appear
+        result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        assert result.exit_code == 0, result.output
+        assert str(TOTAL_FRAMES) in result.output
+
+    def test_cached_file_synopsis_shows_protocol(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        assert result.exit_code == 0, result.output
+        assert "UDP" in result.output or "TCP" in result.output
+
+    def test_cached_file_synopsis_shows_top_talker(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
+        assert result.exit_code == 0, result.output
+        assert UDP_TOP_TALKER_IP in result.output


### PR DESCRIPTION
## Summary

Two related bugs when launching `pcap-agent` with a PCAP file argument:

1. The agent had no knowledge of the file that the CLI pre-ingested, so
   it responded "No PCAP file has been ingested yet" to any question.
2. No synopsis was shown after loading a file — neither for new files nor
   for files already in the cache — making the cached case feel broken
   compared to the REPL workflow where the agent interprets tool results.

## Changes

- `agent.py`: `create_agent()` now accepts an optional `pcap_file`
  parameter. When set, the system prompt is extended with a note that
  the file is already ingested and ready for analysis, so the LLM starts
  the session with the correct context.
- `cli.py`: passes `pcap_file` through to `create_agent()`; adds
  `_print_synopsis()` which prints file name, packet count, protocol
  breakdown, and top talker to stdout after every successful ingest —
  new or cached.
- `tests/test_agent.py`: two tests verifying the system prompt contains
  the file path when provided and omits it when not.
- `tests/test_cli.py`: six tests via `CliRunner` covering both the
  new-file and cached-file paths for packet count, protocols, and top
  talker output.

## Testing

```
# First load (new file) — should print synopsis and agent should know the file
just run-repl ./data/evidence01.pcap
?> what file is loaded?

# Second load (cached) — synopsis must still appear
just run-repl ./data/evidence01.pcap
?> what protocols are present?
```

Expected synopsis format:
```
Loaded evidence01.pcap (from cache) — 278 packets
  Protocols: UDP 73.7%, TCP 25.2%, ICMP 1.1%
  Top talker: 192.168.1.100 (200 packets)
```

Automated: `uv run pytest` — 162 tests pass.

## Related Issues

Closes #27
