### PR TITLE
feat(cli): add --log-file option to route logs to a file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ pytest collects files alphabetically. Tests in `test_query_tool.py` run after `t
 | `PCAP_AGENT_DB_DIR` | `~/.cache/pcap-agent` | Where DuckDB files are stored |
 | `PCAP_AGENT_UI` | `console` | UI mode |
 | `PCAP_AGENT_LOG_LEVEL` | `WARNING` | Root logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
+| `PCAP_AGENT_LOG_FILE` | `""` | Route log output to this file (append mode) instead of stderr |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | OpenTelemetry OTLP endpoint |
 
 Tests set `ANTHROPIC_API_KEY=test-dummy-key` via `pytest_configure` in `conftest.py`.

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -73,6 +73,13 @@ def _print_synopsis(pcap_file: str, result: dict[str, Any]) -> None:
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     help="Logging level [env: PCAP_AGENT_LOG_LEVEL]",
 )
+@click.option(
+    "--log-file",
+    envvar="PCAP_AGENT_LOG_FILE",
+    default="",
+    help="Route log output to this file (append mode) instead of stderr"
+    " [env: PCAP_AGENT_LOG_FILE]",
+)
 def main(
     pcap_file: str | None,
     api_key: str,
@@ -81,6 +88,7 @@ def main(
     db_dir: str,
     otlp_endpoint: str,
     log_level: str,
+    log_file: str,
 ) -> None:
     """PCAP analysis agent powered by Claude.
 
@@ -104,10 +112,15 @@ def main(
     os.environ["PCAP_AGENT_DB_DIR"] = db_dir_expanded
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint
     os.environ["PCAP_AGENT_LOG_LEVEL"] = log_level
+    os.environ["PCAP_AGENT_LOG_FILE"] = log_file
 
     from pcap_agent import telemetry
 
-    telemetry.setup(otlp_endpoint, log_level)
+    try:
+        telemetry.setup(otlp_endpoint, log_level, log_file)
+    except OSError as exc:
+        click.echo(f"Error: cannot open log file: {exc}", err=True)
+        sys.exit(1)
 
     if pcap_file:
         from rich.progress import Progress, SpinnerColumn, TextColumn

--- a/src/pcap_agent/config.py
+++ b/src/pcap_agent/config.py
@@ -16,6 +16,7 @@ class Config:
     pcap_agent_db_dir: str
     otel_exporter_otlp_endpoint: str
     pcap_agent_log_level: str
+    pcap_agent_log_file: str
 
 
 _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
@@ -43,6 +44,7 @@ def _load() -> Config:
         ),
         otel_exporter_otlp_endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
         pcap_agent_log_level=log_level,
+        pcap_agent_log_file=os.environ.get("PCAP_AGENT_LOG_FILE", ""),
     )
 
 

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -12,18 +12,31 @@ from typing import Any, Callable
 _tracer: Any = None
 _meter: Any = None
 _metrics: dict[str, Any] = {}
+_file_handler: logging.FileHandler | None = None
 
 
-def setup(endpoint: str = "", log_level: str = "WARNING") -> None:
+def setup(endpoint: str = "", log_level: str = "WARNING", log_file: str = "") -> None:
     """Initialize OTel SDK with OTLP HTTP exporters. No-op if endpoint is empty."""
-    global _tracer, _meter, _metrics
+    global _tracer, _meter, _metrics, _file_handler
 
-    logging.basicConfig(
-        stream=sys.stderr,
-        level=log_level,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-        force=True,
-    )
+    fmt = "%(asctime)s %(levelname)s %(name)s %(message)s"
+    if log_file:
+        handler = logging.FileHandler(log_file, mode="a")
+        handler.setFormatter(logging.Formatter(fmt))
+        logging.basicConfig(
+            handlers=[handler],
+            level=log_level,
+            format=fmt,
+            force=True,
+        )
+        _file_handler = handler
+    else:
+        logging.basicConfig(
+            stream=sys.stderr,
+            level=log_level,
+            format=fmt,
+            force=True,
+        )
 
     if not endpoint:
         return
@@ -155,8 +168,12 @@ def _record_latency(tool_name: str, elapsed: float) -> None:
 
 def _reset() -> None:
     """Reset module state. For testing only."""
-    global _tracer, _meter, _metrics
+    global _tracer, _meter, _metrics, _file_handler
     _tracer = None
     _meter = None
     _metrics = {}
     logging.getLogger("urllib3").setLevel(logging.NOTSET)
+    if _file_handler is not None:
+        logging.getLogger().removeHandler(_file_handler)
+        _file_handler.close()
+        _file_handler = None

--- a/src/pcap_agent/telemetry.py
+++ b/src/pcap_agent/telemetry.py
@@ -19,6 +19,11 @@ def setup(endpoint: str = "", log_level: str = "WARNING", log_file: str = "") ->
     """Initialize OTel SDK with OTLP HTTP exporters. No-op if endpoint is empty."""
     global _tracer, _meter, _metrics, _file_handler
 
+    if _file_handler is not None:
+        logging.getLogger().removeHandler(_file_handler)
+        _file_handler.close()
+        _file_handler = None
+
     fmt = "%(asctime)s %(levelname)s %(name)s %(message)s"
     if log_file:
         handler = logging.FileHandler(log_file, mode="a")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,13 @@
 """Tests for the CLI entry point."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 from constants import TOTAL_FRAMES, UDP_TOP_TALKER_IP
 
+import pcap_agent.telemetry as telemetry
 from pcap_agent.cli import main
 
 
@@ -86,3 +88,56 @@ class TestCliSynopsis:
         result = self._invoke(cli_runner, mock_chat, synthetic_pcap, str(tmp_path))
         assert result.exit_code == 0, result.output
         assert UDP_TOP_TALKER_IP in result.output
+
+
+class TestCliLogFile:
+    """CLI --log-file option routes logs to a file."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_telemetry(self):
+        telemetry._reset()
+        root = logging.getLogger()
+        orig_level = root.level
+        orig_handlers = root.handlers[:]
+        yield
+        telemetry._reset()
+        root.handlers[:] = orig_handlers
+        root.setLevel(orig_level)
+
+    def test_log_file_produces_nonempty_file(
+        self, synthetic_pcap, tmp_path
+    ):
+        log_path = tmp_path / "agent.log"
+        db_dir = tmp_path / "db"
+        db_dir.mkdir()
+        mock_chat = MagicMock()
+        mock_chat.console.return_value = None
+        runner = CliRunner()
+        with patch("pcap_agent.agent.create_agent", return_value=mock_chat):
+            result = runner.invoke(
+                main,
+                [
+                    str(synthetic_pcap),
+                    "--api-key", "test-key",
+                    "--db-dir", str(db_dir),
+                    "--log-level", "DEBUG",
+                    "--log-file", str(log_path),
+                ],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        assert log_path.exists()
+        assert log_path.stat().st_size > 0
+
+    def test_bad_log_file_path_exits_with_error(self, tmp_path):
+        bad_path = str(tmp_path / "no_such_dir" / "agent.log")
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--api-key", "test-key",
+                "--log-file", bad_path,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Error" in result.output or "Error" in (result.output or "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,14 @@
 import logging
 from unittest.mock import MagicMock, patch
 
+import duckdb
 import pytest
 from click.testing import CliRunner
 from constants import TOTAL_FRAMES, UDP_TOP_TALKER_IP
 
 import pcap_agent.telemetry as telemetry
 from pcap_agent.cli import main
+from pcap_agent.tools import _state
 
 
 @pytest.fixture()
@@ -21,6 +23,28 @@ def mock_chat():
     chat = MagicMock()
     chat.console.return_value = None
     return chat
+
+
+@pytest.fixture(autouse=True)
+def _restore_state():
+    """Save and restore _state around each test.
+
+    CLI tests call ingest_pcap in-process, which closes the prior connection
+    and points _state._conn at a tmp_path DB that is deleted after the test.
+    Re-opening the saved path prevents state pollution for session fixtures.
+    """
+    saved_path = _state.get_db_path()
+    yield
+    current = _state.get_connection()
+    if current is not None:
+        try:
+            current.close()
+        except Exception:
+            pass
+    if saved_path is not None:
+        _state.set_connection(duckdb.connect(saved_path), saved_path)
+    else:
+        _state.reset()
 
 
 class TestCliSynopsis:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -267,3 +267,38 @@ class TestMetricRecording:
         _, metric_reader = memory_telemetry
         telemetry.record_anomalies_detected(3)
         assert _get_metric_sum(metric_reader, "pcap_agent.anomalies_detected") == 3
+
+
+class TestSetupLogFile:
+    def test_file_handler_wired_when_log_file_given(self, tmp_path):
+        log_path = tmp_path / "test.log"
+        telemetry.setup("", log_level="DEBUG", log_file=str(log_path))
+        root = logging.getLogger()
+        assert any(
+            isinstance(h, logging.FileHandler) and h.baseFilename == str(log_path)
+            for h in root.handlers
+        )
+
+    def test_stderr_default_when_no_log_file(self):
+        telemetry.setup("", log_level="WARNING")
+        root = logging.getLogger()
+        assert not any(isinstance(h, logging.FileHandler) for h in root.handlers)
+
+    def test_bad_path_raises_os_error(self, tmp_path):
+        bad_path = str(tmp_path / "nonexistent_dir" / "test.log")
+        with pytest.raises(OSError):
+            telemetry.setup("", log_file=bad_path)
+
+    def test_reset_closes_file_handler(self, tmp_path):
+        log_path = tmp_path / "test.log"
+        telemetry.setup("", log_file=str(log_path))
+        assert telemetry._file_handler is not None
+        telemetry._reset()
+        assert telemetry._file_handler is None
+
+    def test_reset_removes_file_handler_from_root_logger(self, tmp_path):
+        log_path = tmp_path / "test.log"
+        telemetry.setup("", log_file=str(log_path))
+        telemetry._reset()
+        root = logging.getLogger()
+        assert not any(isinstance(h, logging.FileHandler) for h in root.handlers)


### PR DESCRIPTION
## Summary

Add a `--log-file <path>` CLI option (and `PCAP_AGENT_LOG_FILE` env var) that routes all log output to a file in append mode instead of stderr. Omitting the option preserves existing stderr behaviour. A non-writable path causes the CLI to exit immediately with a clear OS error.

## Changes

- `Config`: add `pcap_agent_log_file` field (empty string = no file)
- `telemetry.setup()`: accept `log_file` parameter; wire a `FileHandler` in append mode when set; close any existing `FileHandler` at the top of `setup()` before creating a new one to prevent fd leaks
- `telemetry._reset()`: close and remove the `FileHandler` on teardown
- `cli.py`: add `--log-file` / `PCAP_AGENT_LOG_FILE` option; catch `OSError` from `setup()` and exit with a user-facing error message
- `CLAUDE.md`: document `PCAP_AGENT_LOG_FILE` in the env var table
- Tests: 5 unit tests in `TestSetupLogFile` (file handler wired, stderr default preserved, bad path raises `OSError`, reset closes handler); integration test verifying `--log-file <tmp>` produces a non-empty log file; autouse `_restore_state` fixture in `test_cli.py` to prevent `_state._conn` pollution across session fixtures

## Testing

Unit and integration tests added in `tests/test_telemetry.py` (`TestSetupLogFile`) and `tests/test_cli.py` (`TestCliLogFile`). All 169 tests pass.

```bash
uv run pytest
```

## Related Issues

Closes #29
