### PR TITLE
docs: add README, CONTRIBUTING, architecture, and observability docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing
+
+## Prerequisites
+
+- Python 3.13
+- [uv](https://docs.astral.sh/uv/) — the project uses `uv` for dependency management and running tools; never use `pip3` directly
+- [just](https://just.systems/) — task runner used by the Justfile
+- Docker (optional) — only needed to run the local observability stack
+
+## Setting up the development environment
+
+1. Clone the repository:
+
+   ```bash
+   git clone <repo-url>
+   cd pcap-agent
+   ```
+
+2. Copy the example environment file and fill in your Anthropic API key:
+
+   ```bash
+   cp .envrc.example .envrc
+   # edit .envrc and set ANTHROPIC_API_KEY
+   ```
+
+   If you use [direnv](https://direnv.net/), run `direnv allow` to load the variables automatically. Otherwise source the file manually:
+
+   ```bash
+   source .envrc
+   ```
+
+3. Install dependencies and pre-commit hooks:
+
+   ```bash
+   just setup
+   ```
+
+   This runs `uv sync` and `pre-commit install`.
+
+## Project structure
+
+See [docs/architecture.md](docs/architecture.md) for a full description of the source layout and key design decisions.
+
+## Making changes
+
+### Branch naming
+
+Follow the convention `dsk-<issue-number>-<short-slug>`, e.g. `dsk-42-add-http-tool`.
+
+### Adding a dependency
+
+Always use `uv add`, never `pip3 install`:
+
+```bash
+uv add <package>
+```
+
+For dev-only dependencies:
+
+```bash
+uv add --group dev <package>
+```
+
+### Adding a new tool
+
+1. Create `src/pcap_agent/tools/<name>.py`.
+2. Call `_state.require_connection()` to obtain the DuckDB connection.
+3. Return plain dicts; use `{"error": ..., "hint": ...}` for expected failures.
+4. Register the tool in `agent.py` inside the `_tools` list.
+5. Add integration tests in `tests/test_<name>_tool.py`.
+
+See [docs/architecture.md](docs/architecture.md) for more details.
+
+### Code style
+
+The project uses [ruff](https://docs.astral.sh/ruff/) with rules `E`, `F`, `I` and a line length of 88. Run the linter before committing:
+
+```bash
+just lint
+```
+
+Pre-commit hooks run ruff automatically on staged files, so you will also get feedback at commit time.
+
+## Running tests
+
+Run the full test suite:
+
+```bash
+just test
+```
+
+Or directly with pytest:
+
+```bash
+uv run pytest
+```
+
+To run a single file or test:
+
+```bash
+uv run pytest tests/test_query_tool.py
+uv run pytest tests/test_query_tool.py::TestQuery::test_select_all
+```
+
+### Test fixtures
+
+| Fixture | Scope | Description |
+|---|---|---|
+| `ingested_db` | session | Ingests the synthetic PCAP once and sets `_state._conn`. Use for any test that needs data in the DB. |
+| `ingested_conn` | session | Returns `_state.require_connection()` after `ingested_db` runs. Use when you need the raw connection. |
+| `duckdb_conn` | function | Fresh in-memory connection with schema applied. Use for DB-layer unit tests that don't need the full ingest pipeline. |
+
+### Important test isolation notes
+
+- `ingest_pcap` closes `_state._conn` when switching databases. Never restore a saved connection object after calling `ingest_pcap` with a different `db_dir` — re-open via `duckdb.connect(saved_path)` instead.
+- When a test needs custom DB state that the shared session fixture does not provide, swap the singleton using `_state.set_connection()` inside a function-scoped fixture and restore it in teardown.
+- pytest collects files alphabetically. Test ordering matters because the session-scoped `_state._conn` is shared across all files. See `CLAUDE.md` for the full pitfall list.
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+```
+
+Common types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`.
+
+Example: `feat(tools): add http-request reassembly tool`
+
+## Environment variables reference
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | (required) | Claude API key |
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | Claude model to use |
+| `PCAP_AGENT_DB_DIR` | `~/.cache/pcap-agent` | Directory for DuckDB storage |
+| `PCAP_AGENT_UI` | `console` | UI mode (`console` or `app`) |
+| `PCAP_AGENT_LOG_LEVEL` | `WARNING` | Root logger level |
+| `PCAP_AGENT_LOG_FILE` | `""` | Route logs to this file instead of stderr |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | OpenTelemetry OTLP endpoint (empty = telemetry off) |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,118 @@
 # pcap-agent
+
+AI-powered network traffic analyst. Point it at a PCAP file and ask questions in plain English — the agent ingests the capture into a local DuckDB database, then uses Claude to answer questions, detect anomalies, and reconstruct TCP/UDP streams.
+
+## Features
+
+- Natural-language interface to packet data powered by Claude
+- Fast SQL queries over DuckDB (millions of packets, sub-second responses)
+- Protocol breakdown and top-talkers analysis out of the box
+- Port-scan and anomaly detection (IsolationForest)
+- TCP/UDP stream reassembly with up to 64 KB payload
+- Console REPL and Shiny web UI
+- OpenTelemetry traces, metrics, and structured logs (optional)
+
+## Prerequisites
+
+| Requirement | Version |
+|---|---|
+| Python | 3.13+ |
+| [uv](https://docs.astral.sh/uv/) | latest |
+| [just](https://just.systems/) | latest |
+| Docker | optional — for the local observability stack |
+
+An **Anthropic API key** is required. Get one at <https://console.anthropic.com>.
+
+## Setup
+
+1. Clone the repository:
+
+   ```bash
+   git clone <repo-url>
+   cd pcap-agent
+   ```
+
+2. Configure environment variables:
+
+   ```bash
+   cp .envrc.example .envrc
+   # edit .envrc — at minimum set ANTHROPIC_API_KEY
+   source .envrc          # or: direnv allow
+   ```
+
+3. Install dependencies and pre-commit hooks:
+
+   ```bash
+   just setup
+   ```
+
+## Getting started
+
+Ingest a PCAP file and start the console REPL in one command:
+
+```bash
+just run-repl capture.pcap
+```
+
+Or use the Shiny web UI:
+
+```bash
+just run-app capture.pcap
+```
+
+You can also omit the file and provide it once the session starts:
+
+```bash
+just run-repl
+# agent will prompt you for a path
+```
+
+### Example session
+
+```
+Loaded capture.pcap (new) — 4 213 packets
+  Protocols: TCP 72%, UDP 21%, ICMP 7%
+  Top talker: 192.168.1.5 (1 847 packets)
+
+> What are the top destination ports?
+> Are there any signs of a port scan?
+> Reassemble the TCP stream between 192.168.1.5 and 10.0.0.1
+```
+
+## Configuration
+
+All options can be set via CLI flags or environment variables. CLI flags take precedence.
+
+| Variable | Default | CLI flag | Description |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | (required) | `--api-key` | Anthropic API key |
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | `--model` | Claude model name |
+| `PCAP_AGENT_DB_DIR` | `~/.cache/pcap-agent` | `--db-dir` | Directory for DuckDB storage |
+| `PCAP_AGENT_UI` | `console` | `--ui` | UI mode: `console` or `app` |
+| `PCAP_AGENT_LOG_LEVEL` | `WARNING` | `--log-level` | Log level: `DEBUG` `INFO` `WARNING` `ERROR` `CRITICAL` |
+| `PCAP_AGENT_LOG_FILE` | `""` | `--log-file` | Write logs to a file instead of stderr |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | `--otlp-endpoint` | OTLP endpoint (empty = telemetry off) |
+
+Set variables in `.envrc` (or `.env`) to avoid repeating them on every invocation.
+
+## Documentation
+
+- [Architecture](docs/architecture.md) — source layout, data flow, and design decisions
+- [Observability](docs/observability.md) — logging, tracing, metrics, and the local Grafana stack
+- [Contributing](CONTRIBUTING.md) — dev environment setup, testing, and contribution guidelines
+
+## Justfile targets
+
+| Target | Description |
+|---|---|
+| `just setup` | Install dependencies and pre-commit hooks |
+| `just test` | Run the test suite |
+| `just lint` | Run ruff over `src` and `tests` |
+| `just run-repl [args...]` | Start the console REPL |
+| `just run-app [args...]` | Start the Shiny web UI |
+| `just grafana-up` | Start the local Grafana / OTLP stack (Docker) |
+| `just grafana-down` | Stop and remove the Grafana container |
+
+## License
+
+See [LICENSE](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture
+
+pcap-agent is a single-process CLI application that ingests PCAP files into a local DuckDB database and exposes a Claude-powered conversational interface for querying and analysing the captured network traffic.
+
+## High-level flow
+
+```
+PCAP file
+   │
+   ▼
+parser.py          Scapy → Polars DataFrames (ParsedPcap)
+   │
+   ▼
+db.py              DuckDB schema DDL + bulk insert via executemany
+   │
+   ▼
+tools/_state.py    Module-level singleton DuckDB connection
+   │
+   ├── tools/analysis.py      get_protocol_breakdown(), get_top_talkers()
+   ├── tools/query.py         query()  — validated ad-hoc SQL
+   ├── tools/detection.py     detect_port_scans(), detect_anomalies()
+   └── tools/reassembly.py    reassemble_stream()
+         │
+         ▼
+agent.py           ChatAnthropic session — all 7 tools registered + OTel-wrapped
+         │
+         ▼
+cli.py             Click entry point — flags → env vars → ingest spinner → chat UI
+```
+
+## Source layout
+
+```
+src/pcap_agent/
+  config.py          Frozen Config dataclass, loaded once from env / .env at import time
+  agent.py           create_agent() — ChatAnthropic session with all 7 tools
+  cli.py             Click entry point: flags, spinner ingest, console/app dispatch
+  db.py              DuckDB schema DDL, ingest(), get_cached() / set_cached()
+  parser.py          Scapy → Polars DataFrames (ParsedPcap)
+  telemetry.py       OTel SDK init (setup()), instrument_tool(), metric helpers
+  tools/
+    _state.py        Module-level singleton connection: set / get / require / reset
+    ingest.py        ingest_pcap() — parse + persist + auto-run analysis
+    analysis.py      get_protocol_breakdown(), get_top_talkers()
+    query.py         query() — validated ad-hoc SQL with safety guardrails
+    detection.py     detect_port_scans(), detect_anomalies() — on-demand only
+    reassembly.py    reassemble_stream() — TCP/UDP payload reassembly (64 KB cap)
+```
+
+## Database schema
+
+```sql
+packets        (packet_id PK, timestamp, src_ip, dst_ip, protocol, length, ttl)
+tcp_segments   (packet_id FK, sport, dport, flags, seq, ack, payload BLOB)
+udp_datagrams  (packet_id FK, sport, dport, payload BLOB)
+icmp_messages  (packet_id FK, type, code, payload BLOB)
+pcap_meta      (sha256 PK, pcap_path, ingested_at)  -- content-addressed cache
+```
+
+`pcap_meta` is used to skip re-parsing a file that has already been ingested. The SHA-256 of the PCAP file is the cache key, so the same file stored at a different path is still recognised as a cache hit.
+
+## Key design decisions
+
+### Single shared DuckDB connection
+
+All tools share one `duckdb.Connection` object stored in `tools/_state.py`. There is no connection pool and no locking. This is intentional: DuckDB's single-writer model and the strictly single-threaded CLI use case make a pool unnecessary. The connection is opened at ingest time and reused for the lifetime of the session.
+
+When `ingest_pcap` is called with a different `db_dir`, it closes the current connection before opening a new one. Any caller that holds a reference to the old connection object must re-open by path rather than restoring the closed handle.
+
+### Tools return plain dicts
+
+All tool functions return `dict` objects so the agent can directly serialise and reason about the data without extra marshalling. Expected errors (bad SQL, no data ingested) return `{"error": "...", "hint": "..."}` so the agent can self-correct without crashing. Unexpected exceptions propagate normally.
+
+### Agent system prompt
+
+`agent.py` uses a terse, security-analyst persona. When a PCAP file is provided on the CLI, the path is appended to the system prompt so the agent knows the data is already loaded and can skip the ingest step.
+
+### Config loading order
+
+`config.py` runs `_load()` at module import time and raises immediately if `ANTHROPIC_API_KEY` is unset. To allow CLI flags to override environment variables, `cli.py` writes flag values into `os.environ` *before* importing any module that transitively imports `config`. All `pcap_agent` imports are therefore deferred to the body of the `main()` function rather than placed at the top of `cli.py`.
+
+## Adding a new tool
+
+1. Create `src/pcap_agent/tools/<name>.py`.
+2. Call `_state.require_connection()` to obtain the connection — this raises `RuntimeError` when no PCAP has been ingested yet.
+3. Return plain dicts; use `{"error": ..., "hint": ...}` for expected failures.
+4. Register the tool in `agent.py` inside the `_tools` list.
+5. Add integration tests in `tests/test_<name>_tool.py` using the `ingested_db` session fixture.
+6. Run `uv run ruff check` and `uv run pytest`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,91 @@
+# Observability
+
+pcap-agent emits structured logs, distributed traces, and metrics via the [OpenTelemetry](https://opentelemetry.io/) SDK. Telemetry is **off by default** — the application runs normally with no external dependencies until an OTLP endpoint is configured.
+
+## Logging
+
+Logging is always enabled. The root logger is configured in `telemetry.setup()` via `logging.basicConfig(..., force=True)`.
+
+| Option | Default | Description |
+|---|---|---|
+| `--log-level` / `PCAP_AGENT_LOG_LEVEL` | `WARNING` | Minimum log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
+| `--log-file` / `PCAP_AGENT_LOG_FILE` | `""` (stderr) | Write logs to this file in append mode instead of stderr |
+
+Example — write `DEBUG` logs to a file:
+
+```bash
+pcap-agent --log-level DEBUG --log-file pcap-agent.log capture.pcap
+```
+
+Or via environment variables:
+
+```bash
+export PCAP_AGENT_LOG_LEVEL=DEBUG
+export PCAP_AGENT_LOG_FILE=pcap-agent.log
+pcap-agent capture.pcap
+```
+
+## Traces and metrics
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the agent initialises three OTLP HTTP exporters:
+
+| Signal | Endpoint path |
+|---|---|
+| Traces | `<base>/v1/traces` |
+| Metrics | `<base>/v1/metrics` |
+| Logs bridge | `<base>/v1/logs` |
+
+All seven tool functions are wrapped with `instrument_tool()` in `agent.py`. Each call produces an OTel span named after the function. Span attributes include the tool name and every argument (stringified).
+
+### Metrics
+
+| Metric name | Type | Description |
+|---|---|---|
+| `pcap_agent.packets_ingested` | Counter | Total packets inserted into DuckDB |
+| `pcap_agent.queries_run` | Counter | Total ad-hoc SQL queries executed |
+| `pcap_agent.anomalies_detected` | Counter | Total anomalies returned by `detect_anomalies` |
+| `pcap_agent.tool_call_latency` | Histogram (seconds) | Wall-clock duration of each tool call, labelled by `tool` |
+
+## Local observability stack
+
+A ready-to-use all-in-one stack based on [grafana/otel-lgtm](https://hub.docker.com/r/grafana/otel-lgtm) (Loki + Grafana + Tempo + Mimir) is provided via the Justfile.
+
+**Start the stack:**
+
+```bash
+just grafana-up
+```
+
+This starts a Docker container that exposes:
+
+| Service | URL |
+|---|---|
+| Grafana UI | <http://localhost:3000> |
+| OTLP HTTP endpoint | <http://localhost:4318> |
+
+**Configure the agent to send telemetry:**
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+pcap-agent capture.pcap
+```
+
+Or set it in your `.env` file:
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+**Stop the stack:**
+
+```bash
+just grafana-down
+```
+
+## Implementation details
+
+The telemetry module (`src/pcap_agent/telemetry.py`) is structured so that no OTel SDK packages are imported unless an endpoint is configured. This means the application starts without error even when the OTel SDK packages are absent from the environment (they are included as runtime dependencies but the import is lazy).
+
+The `instrument_tool()` decorator is a no-op when `_tracer is None`, so all tool functions work identically with or without telemetry enabled.
+
+Metric counters are recorded inside the tool functions themselves (not only in the decorator) so that the CLI ingest step — which runs before the agent loop starts — also contributes to the metrics.


### PR DESCRIPTION
## Summary

Adds a full documentation suite for the project, replacing the stub README with a proper project overview and introducing three new docs covering architecture, observability, and contribution guidelines.

## Changes

- **README.md** — project overview, features, prerequisites, setup steps, getting started examples, full configuration table, and links to the other docs
- **CONTRIBUTING.md** — dev environment setup, branch naming convention, how to add dependencies and tools, code style, test fixture reference, test isolation pitfalls, and commit message guidelines
- **docs/architecture.md** — data flow diagram, source layout, database schema, and key design decisions (shared DuckDB connection, plain-dict tool returns, config loading order, adding a new tool)
- **docs/observability.md** — logging options, OTel traces and metrics reference, local Grafana/OTLP stack instructions, and notes on the lazy-import no-op design

## Testing

Documentation only — no code changes. Verify by reading each file and confirming links between documents are correct.

## Related Issues

None
