### PR TITLE
refactor: rename packet_id to frame_id across the codebase

### DIFF
--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 _DDL = """
 CREATE TABLE IF NOT EXISTS packets (
-    packet_id BIGINT PRIMARY KEY,
+    frame_id BIGINT PRIMARY KEY,
     timestamp DOUBLE,
     src_ip VARCHAR,
     dst_ip VARCHAR,
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS packets (
 );
 
 CREATE TABLE IF NOT EXISTS tcp_segments (
-    packet_id BIGINT,
+    frame_id BIGINT,
     sport INTEGER,
     dport INTEGER,
     flags VARCHAR,
@@ -34,14 +34,14 @@ CREATE TABLE IF NOT EXISTS tcp_segments (
 );
 
 CREATE TABLE IF NOT EXISTS udp_datagrams (
-    packet_id BIGINT,
+    frame_id BIGINT,
     sport INTEGER,
     dport INTEGER,
     payload BLOB
 );
 
 CREATE TABLE IF NOT EXISTS icmp_messages (
-    packet_id BIGINT,
+    frame_id BIGINT,
     type INTEGER,
     code INTEGER,
     payload BLOB

--- a/src/pcap_agent/parser.py
+++ b/src/pcap_agent/parser.py
@@ -15,7 +15,7 @@ _PROTO_ICMP = 1
 _PROTO_ICMPV6 = 58
 
 _PACKETS_SCHEMA = {
-    "packet_id": pl.Int64,
+    "frame_id": pl.Int64,
     "timestamp": pl.Float64,
     "src_ip": pl.String,
     "dst_ip": pl.String,
@@ -25,7 +25,7 @@ _PACKETS_SCHEMA = {
 }
 
 _TCP_SCHEMA = {
-    "packet_id": pl.Int64,
+    "frame_id": pl.Int64,
     "sport": pl.Int32,
     "dport": pl.Int32,
     "flags": pl.String,
@@ -35,14 +35,14 @@ _TCP_SCHEMA = {
 }
 
 _UDP_SCHEMA = {
-    "packet_id": pl.Int64,
+    "frame_id": pl.Int64,
     "sport": pl.Int32,
     "dport": pl.Int32,
     "payload": pl.Binary,
 }
 
 _ICMP_SCHEMA = {
-    "packet_id": pl.Int64,
+    "frame_id": pl.Int64,
     "type": pl.Int32,
     "code": pl.Int32,
     "payload": pl.Binary,
@@ -66,8 +66,8 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
     tcp_rows: list[dict] = []
     udp_rows: list[dict] = []
     icmp_rows: list[dict] = []
-    # packet_id is a sequential index over IP-only frames, not the PCAP frame number.
-    packet_id = 0
+    # frame_id is a sequential index over IP-only frames, not the PCAP frame number.
+    frame_id = 0
 
     for pkt in raw_packets:
         if pkt.haslayer(IP):
@@ -96,7 +96,7 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
 
         packets_rows.append(
             {
-                "packet_id": packet_id,
+                "frame_id": frame_id,
                 "timestamp": float(pkt.time),
                 "src_ip": src_ip,
                 "dst_ip": dst_ip,
@@ -114,7 +114,7 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
             tcp = pkt[TCP]
             tcp_rows.append(
                 {
-                    "packet_id": packet_id,
+                    "frame_id": frame_id,
                     "sport": int(tcp.sport),
                     "dport": int(tcp.dport),
                     "flags": str(tcp.flags),
@@ -127,7 +127,7 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
             udp = pkt[UDP]
             udp_rows.append(
                 {
-                    "packet_id": packet_id,
+                    "frame_id": frame_id,
                     "sport": int(udp.sport),
                     "dport": int(udp.dport),
                     "payload": bytes(udp.payload) if udp.payload else b"",
@@ -137,7 +137,7 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
             icmp = pkt[ICMP]
             icmp_rows.append(
                 {
-                    "packet_id": packet_id,
+                    "frame_id": frame_id,
                     "type": int(icmp.type),
                     "code": int(icmp.code),
                     "payload": bytes(icmp.payload) if icmp.payload else b"",
@@ -148,14 +148,14 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
             if icmpv6 and hasattr(icmpv6, "type"):
                 icmp_rows.append(
                     {
-                        "packet_id": packet_id,
+                        "frame_id": frame_id,
                         "type": int(icmpv6.type),
                         "code": int(icmpv6.code) if hasattr(icmpv6, "code") else 0,
                         "payload": bytes(icmpv6.payload) if icmpv6.payload else b"",
                     }
                 )
 
-        packet_id += 1
+        frame_id += 1
 
     logger.info("Parsed %d IP/IPv6 packets from %s", len(packets_rows), pcap_path)
     logger.debug(

--- a/src/pcap_agent/tools/detection.py
+++ b/src/pcap_agent/tools/detection.py
@@ -15,10 +15,10 @@ logger = logging.getLogger(__name__)
 _PORT_SCAN_SQL = """
 WITH port_contacts AS (
     SELECT p.src_ip, t.dport
-    FROM packets p JOIN tcp_segments t ON p.packet_id = t.packet_id
+    FROM packets p JOIN tcp_segments t ON p.frame_id = t.frame_id
     UNION ALL
     SELECT p.src_ip, u.dport
-    FROM packets p JOIN udp_datagrams u ON p.packet_id = u.packet_id
+    FROM packets p JOIN udp_datagrams u ON p.frame_id = u.frame_id
 )
 SELECT src_ip, COUNT(DISTINCT dport) AS distinct_ports
 FROM port_contacts
@@ -28,15 +28,15 @@ ORDER BY distinct_ports DESC
 
 _ANOMALY_SQL = """
 WITH payload_sizes AS (
-    SELECT packet_id, OCTET_LENGTH(payload) AS payload_size FROM tcp_segments
+    SELECT frame_id, OCTET_LENGTH(payload) AS payload_size FROM tcp_segments
     UNION ALL
-    SELECT packet_id, OCTET_LENGTH(payload) AS payload_size FROM udp_datagrams
+    SELECT frame_id, OCTET_LENGTH(payload) AS payload_size FROM udp_datagrams
     UNION ALL
-    SELECT packet_id, OCTET_LENGTH(payload) AS payload_size FROM icmp_messages
+    SELECT frame_id, OCTET_LENGTH(payload) AS payload_size FROM icmp_messages
 ),
 enriched AS (
     SELECT
-        p.packet_id,
+        p.frame_id,
         p.timestamp,
         p.src_ip,
         p.dst_ip,
@@ -44,21 +44,21 @@ enriched AS (
         p.length,
         COALESCE(ps.payload_size, 0) AS payload_size,
         COALESCE(
-            p.timestamp - LAG(p.timestamp) OVER (ORDER BY p.timestamp, p.packet_id),
+            p.timestamp - LAG(p.timestamp) OVER (ORDER BY p.timestamp, p.frame_id),
             0.0
         ) AS inter_arrival
     FROM packets p
-    LEFT JOIN payload_sizes ps ON p.packet_id = ps.packet_id
+    LEFT JOIN payload_sizes ps ON p.frame_id = ps.frame_id
 )
 SELECT
-    packet_id, timestamp, src_ip, dst_ip,
+    frame_id, timestamp, src_ip, dst_ip,
     protocol, length, payload_size, inter_arrival
 FROM enriched
 ORDER BY timestamp
 """
 
 _ANOMALY_COLS = [
-    "packet_id", "timestamp", "src_ip", "dst_ip",
+    "frame_id", "timestamp", "src_ip", "dst_ip",
     "protocol", "length", "payload_size", "inter_arrival",
 ]
 

--- a/src/pcap_agent/tools/reassembly.py
+++ b/src/pcap_agent/tools/reassembly.py
@@ -43,7 +43,7 @@ def reassemble_stream(
             """
             SELECT FIRST(t.payload) AS payload
             FROM tcp_segments t
-            JOIN packets p ON p.packet_id = t.packet_id
+            JOIN packets p ON p.frame_id = t.frame_id
             WHERE p.src_ip = ?
               AND p.dst_ip = ?
               AND t.sport = ?
@@ -59,7 +59,7 @@ def reassemble_stream(
             """
             SELECT u.payload
             FROM udp_datagrams u
-            JOIN packets p ON p.packet_id = u.packet_id
+            JOIN packets p ON p.frame_id = u.frame_id
             WHERE p.src_ip = ?
               AND p.dst_ip = ?
               AND u.sport = ?

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -71,11 +71,11 @@ class TestIngestRollback:
     """Verify ingest() rolls back on mid-ingest failure."""
 
     def test_rollback_on_failure(self, duckdb_conn, parsed_pcap):
-        # Pre-insert packet_id=0 to trigger a PRIMARY KEY violation on the
+        # Pre-insert frame_id=0 to trigger a PRIMARY KEY violation on the
         # second ingest() call, forcing a failure after _load_df("packets").
         duckdb_conn.execute(
             "INSERT INTO packets"
-            " (packet_id, timestamp, src_ip, dst_ip, protocol, length, ttl)"
+            " (frame_id, timestamp, src_ip, dst_ip, protocol, length, ttl)"
             " VALUES (0, 0.0, '0.0.0.0', '0.0.0.0', 0, 0, 0)"
         )
         with pytest.raises(duckdb.ConstraintException):

--- a/tests/test_detection_tools.py
+++ b/tests/test_detection_tools.py
@@ -74,7 +74,7 @@ class TestDetectAnomalies:
         result = detect_anomalies(contamination=0.02)
         assert len(result) > 0
         expected = {
-            "packet_id", "timestamp", "src_ip", "dst_ip",
+            "frame_id", "timestamp", "src_ip", "dst_ip",
             "protocol", "length", "payload_size", "inter_arrival", "anomaly_score",
         }
         assert set(result[0].keys()) == expected

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,8 +2,6 @@
 
 import logging
 
-import pytest
-
 from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
 from pcap_agent.tools.query import query
 
@@ -123,7 +121,9 @@ class TestQueryLogging:
         with caplog.at_level(logging.WARNING, logger="pcap_agent.tools.query"):
             query("DROP TABLE packets")
 
-        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        warning_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
         assert any("DROP" in msg for msg in warning_msgs)
 
     def test_duckdb_error_logged_at_error(self, ingested_db, caplog):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -43,7 +43,7 @@ class TestParsedPcapTypes:
 
     def test_packets_schema(self, parsed_pcap):
         expected = {
-            "packet_id": pl.Int64,
+            "frame_id": pl.Int64,
             "timestamp": pl.Float64,
             "src_ip": pl.String,
             "dst_ip": pl.String,
@@ -55,7 +55,7 @@ class TestParsedPcapTypes:
 
     def test_tcp_segments_schema(self, parsed_pcap):
         expected = {
-            "packet_id": pl.Int64,
+            "frame_id": pl.Int64,
             "sport": pl.Int32,
             "dport": pl.Int32,
             "flags": pl.String,
@@ -67,7 +67,7 @@ class TestParsedPcapTypes:
 
     def test_udp_datagrams_schema(self, parsed_pcap):
         expected = {
-            "packet_id": pl.Int64,
+            "frame_id": pl.Int64,
             "sport": pl.Int32,
             "dport": pl.Int32,
             "payload": pl.Binary,
@@ -76,7 +76,7 @@ class TestParsedPcapTypes:
 
     def test_icmp_messages_schema(self, parsed_pcap):
         expected = {
-            "packet_id": pl.Int64,
+            "frame_id": pl.Int64,
             "type": pl.Int32,
             "code": pl.Int32,
             "payload": pl.Binary,
@@ -107,9 +107,9 @@ class TestTcpStreamSpotCheck:
         assert len(self.tcp) == TCP_PACKET_COUNT
 
     def test_src_ip(self, parsed_pcap):
-        pkt_ids = self.tcp["packet_id"].to_list()
+        pkt_ids = self.tcp["frame_id"].to_list()
         src_ips = (
-            parsed_pcap.packets.filter(pl.col("packet_id").is_in(pkt_ids))["src_ip"]
+            parsed_pcap.packets.filter(pl.col("frame_id").is_in(pkt_ids))["src_ip"]
             .unique()
             .to_list()
         )
@@ -127,12 +127,12 @@ class TestUdpTopTalkerSpotCheck:
     def _top_talker(self, parsed_pcap):
         pkt_ids = (
             parsed_pcap.packets.filter(pl.col("src_ip") == UDP_TOP_TALKER_IP)[
-                "packet_id"
+                "frame_id"
             ]
             .to_list()
         )
         self.udp = parsed_pcap.udp_datagrams.filter(
-            pl.col("packet_id").is_in(pkt_ids)
+            pl.col("frame_id").is_in(pkt_ids)
         )
 
     def test_row_count(self):
@@ -157,9 +157,9 @@ class TestUdpAnomalySpotCheck:
         assert self.udp["dport"].unique().to_list() == [ANOMALY_DPORT]
 
     def test_src_ip(self, parsed_pcap):
-        pkt_ids = self.udp["packet_id"].to_list()
+        pkt_ids = self.udp["frame_id"].to_list()
         src_ips = (
-            parsed_pcap.packets.filter(pl.col("packet_id").is_in(pkt_ids))["src_ip"]
+            parsed_pcap.packets.filter(pl.col("frame_id").is_in(pkt_ids))["src_ip"]
             .unique()
             .to_list()
         )
@@ -181,18 +181,18 @@ class TestIcmpSpotCheck:
         assert self.icmp["code"].unique().to_list() == [ICMP_CODE]
 
     def test_src_ip(self, parsed_pcap):
-        pkt_ids = self.icmp["packet_id"].to_list()
+        pkt_ids = self.icmp["frame_id"].to_list()
         src_ips = (
-            parsed_pcap.packets.filter(pl.col("packet_id").is_in(pkt_ids))["src_ip"]
+            parsed_pcap.packets.filter(pl.col("frame_id").is_in(pkt_ids))["src_ip"]
             .unique()
             .to_list()
         )
         assert src_ips == [ICMP_SRC_IP]
 
     def test_dst_ip(self, parsed_pcap):
-        pkt_ids = self.icmp["packet_id"].to_list()
+        pkt_ids = self.icmp["frame_id"].to_list()
         dst_ips = (
-            parsed_pcap.packets.filter(pl.col("packet_id").is_in(pkt_ids))["dst_ip"]
+            parsed_pcap.packets.filter(pl.col("frame_id").is_in(pkt_ids))["dst_ip"]
             .unique()
             .to_list()
         )

--- a/tests/test_reassembly_tool.py
+++ b/tests/test_reassembly_tool.py
@@ -179,10 +179,12 @@ class TestTCPRetransmission:
     def retransmit_conn(self, duckdb_conn):
         payload = b"hello"
         duckdb_conn.execute(
-            "INSERT INTO packets VALUES (1, 1700000000.0, '1.1.1.1', '2.2.2.2', 6, 50, 64)"
+            "INSERT INTO packets VALUES "
+            "(1, 1700000000.0, '1.1.1.1', '2.2.2.2', 6, 50, 64)"
         )
         duckdb_conn.execute(
-            "INSERT INTO packets VALUES (2, 1700000001.0, '1.1.1.1', '2.2.2.2', 6, 50, 64)"
+            "INSERT INTO packets VALUES "
+            "(2, 1700000001.0, '1.1.1.1', '2.2.2.2', 6, 50, 64)"
         )
         duckdb_conn.execute(
             "INSERT INTO tcp_segments VALUES (1, 5000, 80, 'PA', 1000, 0, ?)", [payload]


### PR DESCRIPTION
## Summary

Renames the `packet_id` row identifier to `frame_id` in every layer —
DDL, parser, all tool SQL, and all tests — to align with L2 terminology
before new tables are added. Pure rename with no behaviour changes.

Also fixes pre-existing ruff violations in `test_logging.py` (unused
import, line > 88 chars) and `test_reassembly_tool.py` (lines > 88
chars) so that `ruff check` passes cleanly.

## Changes

- Rename `packet_id` → `frame_id` in DDL schema (`db.py`)
- Rename `packet_id` → `frame_id` in Polars schemas and parser logic (`parser.py`)
- Update all JOIN conditions and column references in tool SQL (`detection.py`, `reassembly.py`)
- Update all test assertions and column references (`test_db.py`, `test_detection_tools.py`, `test_parser.py`)
- Fix pre-existing ruff lint errors in `test_logging.py` and `test_reassembly_tool.py`

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | `packet_id` does not appear anywhere in `src/` or `tests/` | Yes | `grep` confirms 0 occurrences |
| 2 | All existing tests pass without modification to test logic | Yes | 175/175 passed |
| 3 | `ruff check` passes | Yes | `All checks passed!` |

## Related Issues

Closes #39
