### PR TITLE
feat(schema,parser): add ethernet_frames and arp_packets tables

### DIFF
--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -47,6 +47,25 @@ CREATE TABLE IF NOT EXISTS icmp_messages (
     payload BLOB
 );
 
+CREATE TABLE IF NOT EXISTS ethernet_frames (
+    frame_id   BIGINT PRIMARY KEY,
+    src_mac    VARCHAR,
+    dst_mac    VARCHAR,
+    ethertype  INTEGER,
+    vlan_id    INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS arp_packets (
+    frame_id    BIGINT PRIMARY KEY,
+    hw_type     INTEGER,
+    proto_type  INTEGER,
+    operation   INTEGER,
+    sender_mac  VARCHAR,
+    sender_ip   VARCHAR,
+    target_mac  VARCHAR,
+    target_ip   VARCHAR
+);
+
 CREATE TABLE IF NOT EXISTS pcap_meta (
     sha256 VARCHAR PRIMARY KEY,
     pcap_path VARCHAR,
@@ -82,6 +101,8 @@ def ingest(
         _load_df(conn, "tcp_segments", frames.tcp_segments)
         _load_df(conn, "udp_datagrams", frames.udp_datagrams)
         _load_df(conn, "icmp_messages", frames.icmp_messages)
+        _load_df(conn, "ethernet_frames", frames.ethernet_frames)
+        _load_df(conn, "arp_packets", frames.arp_packets)
         if begin_transaction:
             conn.commit()
     except Exception:

--- a/src/pcap_agent/parser.py
+++ b/src/pcap_agent/parser.py
@@ -5,7 +5,17 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import polars as pl
-from scapy.all import ICMP, IP, TCP, UDP, IPv6, rdpcap  # type: ignore[import-untyped]
+from scapy.all import (  # type: ignore[import-untyped]
+    ARP,
+    ICMP,
+    IP,
+    TCP,
+    UDP,
+    Dot1Q,
+    Ether,
+    IPv6,
+    rdpcap,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +58,25 @@ _ICMP_SCHEMA = {
     "payload": pl.Binary,
 }
 
+_ETHERNET_FRAMES_SCHEMA = {
+    "frame_id": pl.Int64,
+    "src_mac": pl.String,
+    "dst_mac": pl.String,
+    "ethertype": pl.Int32,
+    "vlan_id": pl.Int32,
+}
+
+_ARP_PACKETS_SCHEMA = {
+    "frame_id": pl.Int64,
+    "hw_type": pl.Int32,
+    "proto_type": pl.Int32,
+    "operation": pl.Int32,
+    "sender_mac": pl.String,
+    "sender_ip": pl.String,
+    "target_mac": pl.String,
+    "target_ip": pl.String,
+}
+
 
 @dataclass(frozen=True)
 class ParsedPcap:
@@ -55,6 +84,8 @@ class ParsedPcap:
     tcp_segments: pl.DataFrame
     udp_datagrams: pl.DataFrame
     icmp_messages: pl.DataFrame
+    ethernet_frames: pl.DataFrame
+    arp_packets: pl.DataFrame
 
 
 def parse(pcap_path: Path | str) -> ParsedPcap:
@@ -66,10 +97,43 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
     tcp_rows: list[dict] = []
     udp_rows: list[dict] = []
     icmp_rows: list[dict] = []
-    # frame_id is a sequential index over IP-only frames, not the PCAP frame number.
-    frame_id = 0
+    ethernet_rows: list[dict] = []
+    arp_rows: list[dict] = []
 
-    for pkt in raw_packets:
+    for frame_id, pkt in enumerate(raw_packets):
+        if pkt.haslayer(Ether):
+            ether = pkt[Ether]
+            if pkt.haslayer(Dot1Q):
+                dot1q = pkt[Dot1Q]
+                vlan_id: int | None = int(dot1q.vlan)
+                ethertype = int(dot1q.type)
+            else:
+                vlan_id = None
+                ethertype = int(ether.type)
+            ethernet_rows.append(
+                {
+                    "frame_id": frame_id,
+                    "src_mac": str(ether.src),
+                    "dst_mac": str(ether.dst),
+                    "ethertype": ethertype,
+                    "vlan_id": vlan_id,
+                }
+            )
+            if pkt.haslayer(ARP):
+                arp = pkt[ARP]
+                arp_rows.append(
+                    {
+                        "frame_id": frame_id,
+                        "hw_type": int(arp.hwtype),
+                        "proto_type": int(arp.ptype),
+                        "operation": int(arp.op),
+                        "sender_mac": str(arp.hwsrc),
+                        "sender_ip": str(arp.psrc),
+                        "target_mac": str(arp.hwdst),
+                        "target_ip": str(arp.pdst),
+                    }
+                )
+
         if pkt.haslayer(IP):
             ip_layer = pkt[IP]
             proto = int(ip_layer.proto)
@@ -155,14 +219,14 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
                     }
                 )
 
-        frame_id += 1
-
     logger.info("Parsed %d IP/IPv6 packets from %s", len(packets_rows), pcap_path)
     logger.debug(
-        "Protocol breakdown — TCP: %d, UDP: %d, ICMP: %d",
+        "Protocol breakdown — TCP: %d, UDP: %d, ICMP: %d, Ethernet: %d, ARP: %d",
         len(tcp_rows),
         len(udp_rows),
         len(icmp_rows),
+        len(ethernet_rows),
+        len(arp_rows),
     )
 
     return ParsedPcap(
@@ -178,4 +242,10 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
         icmp_messages=pl.DataFrame(icmp_rows, schema=_ICMP_SCHEMA)
         if icmp_rows
         else pl.DataFrame(schema=_ICMP_SCHEMA),
+        ethernet_frames=pl.DataFrame(ethernet_rows, schema=_ETHERNET_FRAMES_SCHEMA)
+        if ethernet_rows
+        else pl.DataFrame(schema=_ETHERNET_FRAMES_SCHEMA),
+        arp_packets=pl.DataFrame(arp_rows, schema=_ARP_PACKETS_SCHEMA)
+        if arp_rows
+        else pl.DataFrame(schema=_ARP_PACKETS_SCHEMA),
     )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,6 +16,8 @@ _EXPECTED_TABLES = {
     "tcp_segments",
     "udp_datagrams",
     "icmp_messages",
+    "ethernet_frames",
+    "arp_packets",
     "pcap_meta",
 }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,8 +25,12 @@ from constants import (
     UDP_TOTAL,
 )
 from scapy.all import (  # type: ignore[import-untyped]
+    ARP,
+    IP,
     TCP,
     UDP,
+    Dot1Q,
+    Ether,
     ICMPv6EchoRequest,
     IPv6,
     Raw,
@@ -35,11 +39,13 @@ from scapy.all import (  # type: ignore[import-untyped]
 
 
 class TestParsedPcapTypes:
-    def test_returns_four_dataframes(self, parsed_pcap):
+    def test_returns_six_dataframes(self, parsed_pcap):
         assert isinstance(parsed_pcap.packets, pl.DataFrame)
         assert isinstance(parsed_pcap.tcp_segments, pl.DataFrame)
         assert isinstance(parsed_pcap.udp_datagrams, pl.DataFrame)
         assert isinstance(parsed_pcap.icmp_messages, pl.DataFrame)
+        assert isinstance(parsed_pcap.ethernet_frames, pl.DataFrame)
+        assert isinstance(parsed_pcap.arp_packets, pl.DataFrame)
 
     def test_packets_schema(self, parsed_pcap):
         expected = {
@@ -83,6 +89,29 @@ class TestParsedPcapTypes:
         }
         assert parsed_pcap.icmp_messages.schema == pl.Schema(expected)
 
+    def test_ethernet_frames_schema(self, parsed_pcap):
+        expected = {
+            "frame_id": pl.Int64,
+            "src_mac": pl.String,
+            "dst_mac": pl.String,
+            "ethertype": pl.Int32,
+            "vlan_id": pl.Int32,
+        }
+        assert parsed_pcap.ethernet_frames.schema == pl.Schema(expected)
+
+    def test_arp_packets_schema(self, parsed_pcap):
+        expected = {
+            "frame_id": pl.Int64,
+            "hw_type": pl.Int32,
+            "proto_type": pl.Int32,
+            "operation": pl.Int32,
+            "sender_mac": pl.String,
+            "sender_ip": pl.String,
+            "target_mac": pl.String,
+            "target_ip": pl.String,
+        }
+        assert parsed_pcap.arp_packets.schema == pl.Schema(expected)
+
 
 class TestRowCounts:
     def test_packets_total(self, parsed_pcap):
@@ -96,6 +125,14 @@ class TestRowCounts:
 
     def test_icmp_messages_total(self, parsed_pcap):
         assert len(parsed_pcap.icmp_messages) == ICMP_PACKET_COUNT
+
+    def test_no_ethernet_frames_for_raw_ip_capture(self, parsed_pcap):
+        # The synthetic fixture uses raw IP packets (no Ether layer), so
+        # ethernet_frames must be empty — this validates the non-Ethernet path.
+        assert len(parsed_pcap.ethernet_frames) == 0
+
+    def test_no_arp_packets_for_raw_ip_capture(self, parsed_pcap):
+        assert len(parsed_pcap.arp_packets) == 0
 
 
 class TestTcpStreamSpotCheck:
@@ -254,3 +291,139 @@ class TestIPv6Parsing:
         assert len(parsed_ipv6.icmp_messages) == 1
         assert parsed_ipv6.icmp_messages["type"].to_list() == [_IPV6_ICMPV6_TYPE]
         assert parsed_ipv6.icmp_messages["code"].to_list() == [_IPV6_ICMPV6_CODE]
+
+
+_ETH_SRC_MAC = "aa:bb:cc:dd:ee:01"
+_ETH_DST_MAC = "11:22:33:44:55:01"
+_ARP_REQ_SRC_MAC = "aa:bb:cc:dd:ee:02"
+_ARP_REQ_DST_MAC = "ff:ff:ff:ff:ff:ff"
+_ARP_REP_SRC_MAC = "aa:bb:cc:dd:ee:03"
+_ARP_REP_DST_MAC = "aa:bb:cc:dd:ee:02"
+_ARP_SRC_IP = "192.168.10.1"
+_ARP_DST_IP = "192.168.10.2"
+_VLAN_ID = 100
+_ETH_IP_SRC = "10.20.0.1"
+_ETH_IP_DST = "10.20.0.2"
+_VLAN_IP_SRC = "10.30.0.1"
+_VLAN_IP_DST = "10.30.0.2"
+_ETH_IP_ETHERTYPE = 0x0800  # IPv4
+
+
+class TestEthernetParsing:
+    """Ethernet, ARP, and VLAN parsing with dedicated Ether-framed fixture."""
+
+    @pytest.fixture(scope="class")
+    def eth_pcap(self, tmp_path_factory):
+        tmp_path = tmp_path_factory.mktemp("eth_pcap")
+        pcap_path = tmp_path / "ethernet.pcap"
+        pkts = [
+            # Regular Ethernet/IP/UDP frame
+            Ether(src=_ETH_SRC_MAC, dst=_ETH_DST_MAC)
+            / IP(src=_ETH_IP_SRC, dst=_ETH_IP_DST)
+            / UDP(sport=1234, dport=5678)
+            / Raw(load=b"hello"),
+            # ARP request
+            Ether(src=_ARP_REQ_SRC_MAC, dst=_ARP_REQ_DST_MAC)
+            / ARP(
+                op=1,
+                hwsrc=_ARP_REQ_SRC_MAC,
+                psrc=_ARP_SRC_IP,
+                hwdst=_ARP_REQ_DST_MAC,
+                pdst=_ARP_DST_IP,
+            ),
+            # ARP reply
+            Ether(src=_ARP_REP_SRC_MAC, dst=_ARP_REP_DST_MAC)
+            / ARP(
+                op=2,
+                hwsrc=_ARP_REP_SRC_MAC,
+                psrc=_ARP_DST_IP,
+                hwdst=_ARP_REP_DST_MAC,
+                pdst=_ARP_SRC_IP,
+            ),
+            # VLAN-tagged frame (802.1Q)
+            Ether(src=_ETH_SRC_MAC, dst=_ETH_DST_MAC)
+            / Dot1Q(vlan=_VLAN_ID)
+            / IP(src=_VLAN_IP_SRC, dst=_VLAN_IP_DST)
+            / TCP(sport=9000, dport=80, flags="S"),
+        ]
+        wrpcap(str(pcap_path), pkts)
+        return pcap_path
+
+    @pytest.fixture(scope="class")
+    def parsed_eth(self, eth_pcap):
+        from pcap_agent import parser
+
+        return parser.parse(eth_pcap)
+
+    def test_ethernet_frames_row_count(self, parsed_eth):
+        # 4 packets, all with Ether layer
+        assert len(parsed_eth.ethernet_frames) == 4
+
+    def test_ethernet_frame_src_mac(self, parsed_eth):
+        eth_ip_frame = parsed_eth.ethernet_frames.filter(
+            pl.col("frame_id") == 0
+        )
+        assert eth_ip_frame["src_mac"].to_list() == [_ETH_SRC_MAC]
+
+    def test_ethernet_frame_dst_mac(self, parsed_eth):
+        eth_ip_frame = parsed_eth.ethernet_frames.filter(
+            pl.col("frame_id") == 0
+        )
+        assert eth_ip_frame["dst_mac"].to_list() == [_ETH_DST_MAC]
+
+    def test_untagged_frame_vlan_id_is_null(self, parsed_eth):
+        eth_ip_frame = parsed_eth.ethernet_frames.filter(
+            pl.col("frame_id") == 0
+        )
+        assert eth_ip_frame["vlan_id"].to_list() == [None]
+
+    def test_untagged_frame_ethertype(self, parsed_eth):
+        eth_ip_frame = parsed_eth.ethernet_frames.filter(
+            pl.col("frame_id") == 0
+        )
+        assert eth_ip_frame["ethertype"].to_list() == [_ETH_IP_ETHERTYPE]
+
+    def test_arp_row_count(self, parsed_eth):
+        assert len(parsed_eth.arp_packets) == 2
+
+    def test_arp_request_operation(self, parsed_eth):
+        arp_request = parsed_eth.arp_packets.filter(pl.col("frame_id") == 1)
+        assert arp_request["operation"].to_list() == [1]
+
+    def test_arp_reply_operation(self, parsed_eth):
+        arp_reply = parsed_eth.arp_packets.filter(pl.col("frame_id") == 2)
+        assert arp_reply["operation"].to_list() == [2]
+
+    def test_arp_sender_ip(self, parsed_eth):
+        arp_request = parsed_eth.arp_packets.filter(pl.col("frame_id") == 1)
+        assert arp_request["sender_ip"].to_list() == [_ARP_SRC_IP]
+
+    def test_arp_target_ip(self, parsed_eth):
+        arp_request = parsed_eth.arp_packets.filter(pl.col("frame_id") == 1)
+        assert arp_request["target_ip"].to_list() == [_ARP_DST_IP]
+
+    def test_vlan_id_set(self, parsed_eth):
+        vlan_frame = parsed_eth.ethernet_frames.filter(pl.col("frame_id") == 3)
+        assert vlan_frame["vlan_id"].to_list() == [_VLAN_ID]
+
+    def test_vlan_ethertype_is_inner_not_8100(self, parsed_eth):
+        # 0x8100 is the outer 802.1Q tag; ethertype must reflect the inner type
+        vlan_frame = parsed_eth.ethernet_frames.filter(pl.col("frame_id") == 3)
+        assert vlan_frame["ethertype"].to_list() == [_ETH_IP_ETHERTYPE]
+        assert vlan_frame["ethertype"].to_list()[0] != 0x8100
+
+    def test_arp_frames_have_no_ip_packet_row(self, parsed_eth):
+        # ARP frames (frame_id 1 and 2) must not appear in packets table
+        arp_frame_ids = {1, 2}
+        ip_frame_ids = set(parsed_eth.packets["frame_id"].to_list())
+        assert arp_frame_ids.isdisjoint(ip_frame_ids)
+
+    def test_ip_frames_have_ethernet_row(self, parsed_eth):
+        # frame_id 0 (Ether/IP/UDP) and 3 (Ether/VLAN/IP/TCP) are in packets
+        ip_frame_ids = set(parsed_eth.packets["frame_id"].to_list())
+        eth_frame_ids = set(parsed_eth.ethernet_frames["frame_id"].to_list())
+        assert ip_frame_ids.issubset(eth_frame_ids)
+
+    def test_l3_analysis_works_for_ethernet_capture(self, parsed_eth):
+        # IP-bearing Ethernet frames still produce packets rows
+        assert len(parsed_eth.packets) == 2  # Ether/IP/UDP + VLAN/IP/TCP


### PR DESCRIPTION
## Summary

Adds `ethernet_frames` and `arp_packets` to the DuckDB schema and extends
the parser to populate them from every captured frame. Every Ethernet frame
produces an `ethernet_frames` row (src/dst MAC, ethertype, nullable vlan_id);
ARP frames additionally produce an `arp_packets` row (operation, sender/target
MAC and IP). Non-Ethernet captures (raw IP) produce no `ethernet_frames` rows
and all existing L3/L4 analysis continues to work unchanged.

## Changes

- `db.py`: add `ethernet_frames` and `arp_packets` DDL; wire both tables into `ingest()`
- `parser.py`: import `Ether`, `ARP`, `Dot1Q`; add schemas and dataclass fields; switch loop to `enumerate()` so `frame_id` covers all frames; extract Ethernet/VLAN/ARP fields before the IP/IPv6 block
- `test_db.py`: add `ethernet_frames` and `arp_packets` to `_EXPECTED_TABLES`
- `test_parser.py`: schema tests for both new dataframes; non-Ethernet row-count assertions; `TestEthernetParsing` class with a dedicated Ether-framed fixture covering MAC fields, null `vlan_id`, VLAN inner ethertype, ARP request/reply operations, and IP↔ARP frame separation

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | `create_schema()` creates both tables with correct types | Yes | `test_db.py::TestCreateSchema` — `_EXPECTED_TABLES` includes both |
| 2 | Parser populates `ethernet_frames` for every Ethernet frame | Yes | `TestEthernetParsing::test_ethernet_frames_row_count` (4 Ether frames → 4 rows) |
| 3 | Parser populates `arp_packets` with correct `operation` | Yes | `test_arp_request_operation` (op=1), `test_arp_reply_operation` (op=2) |
| 4 | VLAN: `vlan_id` set, `ethertype` reflects inner type | Yes | `test_vlan_id_set`, `test_vlan_ethertype_is_inner_not_8100` |
| 5 | Non-Ethernet: no `ethernet_frames` rows; L3/L4 works | Yes | `TestRowCounts::test_no_ethernet_frames_for_raw_ip_capture`; all existing tests pass |
| 6 | `ingest()` loads both tables | Yes | `db.py:ingest()` — `_load_df` called for both |
| 7 | Parser and DB-layer unit tests cover all cases | Yes | 194 tests pass |
| 8 | `ruff check` and `pytest` pass | Yes | Both pass cleanly |

## Related Issues

Closes #40
Parent: #38
Blocked by: #39 (merged)
