### PR TITLE
feat(schema,parser): add capture_info table for link-layer and radiotap metadata

### DIFF
--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -71,6 +71,15 @@ CREATE TABLE IF NOT EXISTS pcap_meta (
     pcap_path VARCHAR,
     ingested_at TIMESTAMP DEFAULT current_timestamp
 );
+
+CREATE TABLE IF NOT EXISTS capture_info (
+    sha256          VARCHAR PRIMARY KEY,
+    link_type       INTEGER,
+    has_radiotap    BOOLEAN,
+    signal_dbm      DOUBLE,
+    channel         INTEGER,
+    data_rate_mbps  DOUBLE
+);
 """
 
 
@@ -120,6 +129,30 @@ def _load_df(
     placeholders = ", ".join(["?" for _ in df.columns])
     conn.executemany(
         f'INSERT INTO "{table}" ({cols}) VALUES ({placeholders})', df.rows()
+    )
+
+
+def set_capture_info(
+    conn: duckdb.DuckDBPyConnection,
+    sha256: str,
+    link_type: int,
+    has_radiotap: bool,
+    signal_dbm: float | None,
+    channel: int | None,
+    data_rate_mbps: float | None,
+) -> None:
+    """Insert or replace the capture_info row for sha256."""
+    conn.execute(
+        "INSERT INTO capture_info"
+        " (sha256, link_type, has_radiotap, signal_dbm, channel, data_rate_mbps)"
+        " VALUES (?, ?, ?, ?, ?, ?)"
+        " ON CONFLICT (sha256) DO UPDATE SET"
+        "   link_type = EXCLUDED.link_type,"
+        "   has_radiotap = EXCLUDED.has_radiotap,"
+        "   signal_dbm = EXCLUDED.signal_dbm,"
+        "   channel = EXCLUDED.channel,"
+        "   data_rate_mbps = EXCLUDED.data_rate_mbps",
+        [sha256, link_type, has_radiotap, signal_dbm, channel, data_rate_mbps],
     )
 
 

--- a/src/pcap_agent/parser.py
+++ b/src/pcap_agent/parser.py
@@ -14,8 +14,9 @@ from scapy.all import (  # type: ignore[import-untyped]
     Dot1Q,
     Ether,
     IPv6,
-    rdpcap,
+    RadioTap,
 )
+from scapy.utils import PcapReader  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 
@@ -86,12 +87,45 @@ class ParsedPcap:
     icmp_messages: pl.DataFrame
     ethernet_frames: pl.DataFrame
     arp_packets: pl.DataFrame
+    link_type: int
+    has_radiotap: bool
+    signal_dbm: float | None
+    channel: int | None
+    data_rate_mbps: float | None
+
+
+def _freq_to_channel(freq_mhz: int) -> int | None:
+    if 2412 <= freq_mhz <= 2472:
+        return (freq_mhz - 2412) // 5 + 1
+    if freq_mhz == 2484:
+        return 14
+    if 5180 <= freq_mhz <= 5885:
+        return (freq_mhz - 5000) // 5
+    return None
 
 
 def parse(pcap_path: Path | str) -> ParsedPcap:
-    """Parse a PCAP file and return four normalized DataFrames."""
+    """Parse a PCAP file and return normalized DataFrames plus capture metadata."""
     logger.info("Parsing PCAP file: %s", pcap_path)
-    raw_packets = rdpcap(str(pcap_path))
+    with PcapReader(str(pcap_path)) as reader:
+        link_type: int = reader.linktype
+        raw_packets = reader.read_all()
+
+    has_radiotap = False
+    signal_dbm: float | None = None
+    channel: int | None = None
+    data_rate_mbps: float | None = None
+    for pkt in raw_packets:
+        if pkt.haslayer(RadioTap):
+            has_radiotap = True
+            rt = pkt[RadioTap]
+            sig = getattr(rt, "dBm_AntSignal", None)
+            freq = getattr(rt, "ChannelFrequency", None)
+            rate = getattr(rt, "Rate", None)
+            signal_dbm = float(sig) if sig is not None else None
+            channel = _freq_to_channel(freq) if freq is not None else None
+            data_rate_mbps = float(rate) / 2.0 if rate is not None else None
+            break
 
     packets_rows: list[dict] = []
     tcp_rows: list[dict] = []
@@ -248,4 +282,9 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
         arp_packets=pl.DataFrame(arp_rows, schema=_ARP_PACKETS_SCHEMA)
         if arp_rows
         else pl.DataFrame(schema=_ARP_PACKETS_SCHEMA),
+        link_type=link_type,
+        has_radiotap=has_radiotap,
+        signal_dbm=signal_dbm,
+        channel=channel,
+        data_rate_mbps=data_rate_mbps,
     )

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -60,6 +60,15 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     try:
         db.ingest(conn, frames, begin_transaction=False)
         db.set_cached(conn, sha256, str(pcap_path))
+        db.set_capture_info(
+            conn,
+            sha256,
+            frames.link_type,
+            frames.has_radiotap,
+            frames.signal_dbm,
+            frames.channel,
+            frames.data_rate_mbps,
+        )
         conn.commit()
     except Exception:
         conn.rollback()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,6 +19,7 @@ _EXPECTED_TABLES = {
     "ethernet_frames",
     "arp_packets",
     "pcap_meta",
+    "capture_info",
 }
 
 
@@ -132,6 +133,71 @@ class TestSetCached:
         db.set_cached(duckdb_conn, self._SHA256, "/tmp/other.pcap")
         result = db.get_cached(duckdb_conn, self._SHA256)
         assert result["pcap_path"] == self._PATH
+
+
+class TestSetCaptureInfo:
+    _SHA256 = "d" * 64
+
+    def test_inserts_row(self, duckdb_conn):
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
+        row = duckdb_conn.execute(
+            "SELECT link_type, has_radiotap, signal_dbm, channel, data_rate_mbps"
+            " FROM capture_info WHERE sha256 = ?",
+            [self._SHA256],
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 1
+        assert row[1] is False
+        assert row[2] is None
+        assert row[3] is None
+        assert row[4] is None
+
+    def test_non_radiotap_wifi_columns_null(self, duckdb_conn):
+        db.set_capture_info(duckdb_conn, self._SHA256, 228, False, None, None, None)
+        row = duckdb_conn.execute(
+            "SELECT has_radiotap, signal_dbm, channel, data_rate_mbps"
+            " FROM capture_info WHERE sha256 = ?",
+            [self._SHA256],
+        ).fetchone()
+        assert row[0] is False
+        assert row[1] is None
+        assert row[2] is None
+        assert row[3] is None
+
+    def test_radiotap_row(self, duckdb_conn):
+        db.set_capture_info(duckdb_conn, self._SHA256, 127, True, -65.0, 6, 54.0)
+        row = duckdb_conn.execute(
+            "SELECT link_type, has_radiotap, signal_dbm, channel, data_rate_mbps"
+            " FROM capture_info WHERE sha256 = ?",
+            [self._SHA256],
+        ).fetchone()
+        assert row[0] == 127
+        assert row[1] is True
+        assert row[2] == -65.0
+        assert row[3] == 6
+        assert row[4] == 54.0
+
+    def test_upsert_updates_existing_row(self, duckdb_conn):
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
+        db.set_capture_info(duckdb_conn, self._SHA256, 127, True, -70.0, 11, 24.0)
+        row = duckdb_conn.execute(
+            "SELECT link_type, has_radiotap, signal_dbm, channel, data_rate_mbps"
+            " FROM capture_info WHERE sha256 = ?",
+            [self._SHA256],
+        ).fetchone()
+        assert row[0] == 127
+        assert row[1] is True
+        assert row[2] == -70.0
+        assert row[3] == 11
+        assert row[4] == 24.0
+
+    def test_only_one_row_per_sha256(self, duckdb_conn):
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
+        count = duckdb_conn.execute(
+            "SELECT COUNT(*) FROM capture_info WHERE sha256 = ?", [self._SHA256]
+        ).fetchone()[0]
+        assert count == 1
 
 
 class TestGetCached:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -73,6 +73,15 @@ class TestIngestPcap:
     def test_first_ingest_not_cached(self, ingested_db):
         assert ingested_db["cached"] is False
 
+    def test_capture_info_populated(self, ingested_conn, ingested_db):
+        row = ingested_conn.execute(
+            "SELECT link_type, has_radiotap FROM capture_info WHERE sha256 = ?",
+            [ingested_db["sha256"]],
+        ).fetchone()
+        assert row is not None
+        assert isinstance(row[0], int)
+        assert row[1] is False
+
 
 class TestIngestCaching:
     def test_second_ingest_returns_cached(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,9 +30,11 @@ from scapy.all import (  # type: ignore[import-untyped]
     TCP,
     UDP,
     Dot1Q,
+    Dot11,
     Ether,
     ICMPv6EchoRequest,
     IPv6,
+    RadioTap,
     Raw,
     wrpcap,
 )
@@ -427,3 +429,76 @@ class TestEthernetParsing:
     def test_l3_analysis_works_for_ethernet_capture(self, parsed_eth):
         # IP-bearing Ethernet frames still produce packets rows
         assert len(parsed_eth.packets) == 2  # Ether/IP/UDP + VLAN/IP/TCP
+
+    def test_link_type_is_ethernet(self, parsed_eth):
+        assert parsed_eth.link_type == 1  # DLT_EN10MB
+
+    def test_has_radiotap_false_for_ethernet(self, parsed_eth):
+        assert parsed_eth.has_radiotap is False
+
+    def test_wifi_fields_null_for_ethernet(self, parsed_eth):
+        assert parsed_eth.signal_dbm is None
+        assert parsed_eth.channel is None
+        assert parsed_eth.data_rate_mbps is None
+
+
+_RT_SIGNAL_DBM = -65
+_RT_CHANNEL_FREQ = 2437  # channel 6
+_RT_RATE_RAW = 108  # 108 * 0.5 = 54 Mbps
+_RT_EXPECTED_CHANNEL = 6
+_RT_EXPECTED_RATE_MBPS = 54.0
+_RT_LINKTYPE = 127  # DLT_IEEE802_11_RADIO
+
+
+class TestRadiotapParsing:
+    @pytest.fixture(scope="class")
+    def radiotap_pcap(self, tmp_path_factory):
+        tmp_path = tmp_path_factory.mktemp("rt_pcap")
+        pcap_path = tmp_path / "radiotap.pcap"
+        pkts = [
+            RadioTap(
+                present="Rate+Channel+dBm_AntSignal",
+                Rate=_RT_RATE_RAW,
+                ChannelFrequency=_RT_CHANNEL_FREQ,
+                dBm_AntSignal=_RT_SIGNAL_DBM,
+            )
+            / Dot11()
+            / IP(src="10.0.0.1", dst="10.0.0.2")
+            / TCP(sport=1234, dport=80, flags="S"),
+        ]
+        wrpcap(str(pcap_path), pkts)
+        return pcap_path
+
+    @pytest.fixture(scope="class")
+    def parsed_rt(self, radiotap_pcap):
+        from pcap_agent import parser
+
+        return parser.parse(radiotap_pcap)
+
+    def test_link_type_is_radiotap(self, parsed_rt):
+        assert parsed_rt.link_type == _RT_LINKTYPE
+
+    def test_has_radiotap_true(self, parsed_rt):
+        assert parsed_rt.has_radiotap is True
+
+    def test_signal_dbm(self, parsed_rt):
+        assert parsed_rt.signal_dbm == float(_RT_SIGNAL_DBM)
+
+    def test_channel(self, parsed_rt):
+        assert parsed_rt.channel == _RT_EXPECTED_CHANNEL
+
+    def test_data_rate_mbps(self, parsed_rt):
+        assert parsed_rt.data_rate_mbps == _RT_EXPECTED_RATE_MBPS
+
+
+class TestRawIpLinkType:
+    def test_link_type_is_integer(self, parsed_pcap):
+        assert isinstance(parsed_pcap.link_type, int)
+
+    def test_has_radiotap_false(self, parsed_pcap):
+        assert parsed_pcap.has_radiotap is False
+
+    def test_wifi_fields_null(self, parsed_pcap):
+        assert parsed_pcap.signal_dbm is None
+        assert parsed_pcap.channel is None
+        assert parsed_pcap.data_rate_mbps is None


### PR DESCRIPTION
## Summary

Add a `capture_info` table (one row per ingested PCAP, keyed by `sha256`)
that records the PCAP global link-layer type and, for radiotap WiFi captures,
signal strength, channel, and data rate. Non-radiotap captures leave the WiFi
columns NULL.

## Changes

- `db.py`: add `capture_info` DDL to schema and `set_capture_info()` upsert helper (analogous to `set_cached()`)
- `parser.py`: switch from `rdpcap` to `PcapReader` to read `linktype` from the PCAP global header; detect `RadioTap` layer and extract `dBm_AntSignal`, `ChannelFrequency`, and `Rate` from the first radiotap packet; add `link_type`, `has_radiotap`, `signal_dbm`, `channel`, and `data_rate_mbps` fields to `ParsedPcap`
- `ingest.py`: call `set_capture_info()` inside the ingest transaction after parsing

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | `create_schema()` creates `capture_info` with correct columns | Yes | `test_db.py::TestCreateSchema` — `_EXPECTED_TABLES` includes `capture_info` |
| 2 | `set_capture_info()` inserts or replaces a row keyed by `sha256` | Yes | `TestSetCaptureInfo::test_upsert_updates_existing_row` |
| 3 | Parser returns `link_type` and WiFi fields in `ParsedPcap` | Yes | `TestRadiotapParsing` — signal, channel, rate all verified |
| 4 | `ingest()` calls `set_capture_info()` after parsing | Yes | `TestIngestPcap::test_capture_info_populated` |
| 5 | Non-radiotap: `has_radiotap=false`, WiFi columns NULL | Yes | `TestRawIpLinkType`, `TestSetCaptureInfo::test_non_radiotap_wifi_columns_null` |
| 6 | Tests cover Ethernet and loopback link types | Yes | `TestEthernetParsing::test_link_type_is_ethernet` (linktype 1), `TestRawIpLinkType` (linktype 228) |
| 7 | `ruff check` and `pytest` pass | Yes | 211 tests pass, ruff clean |

## Testing

- `uv run pytest` — 211 tests pass
- `uv run ruff check` — no issues
- DB-layer tests cover Ethernet (linktype 1), raw-IP (linktype 228), and radiotap (linktype 127) captures
- Parser tests verify non-radiotap captures have `has_radiotap=False` and NULL WiFi columns; radiotap fixture validates signal, channel, and data rate extraction

## Related Issues

Closes #41
Parent: #38
