### PR TITLE
feat(tools): add get_layer2_summary() agent tool

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -8,6 +8,7 @@ from pcap_agent import telemetry
 from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
 from pcap_agent.tools.detection import detect_anomalies, detect_port_scans
 from pcap_agent.tools.ingest import ingest_pcap
+from pcap_agent.tools.layer2 import get_layer2_summary
 from pcap_agent.tools.query import query
 from pcap_agent.tools.reassembly import reassemble_stream
 
@@ -33,7 +34,7 @@ The data is ready for analysis."
 def create_agent(
     *, api_key: str, model: str, pcap_file: str | None = None
 ) -> "ChatAnthropic":
-    """Return a ChatAnthropic session with all 7 analysis tools registered."""
+    """Return a ChatAnthropic session with all 8 analysis tools registered."""
     system_prompt = _SYSTEM_PROMPT
     if pcap_file:
         system_prompt += _PCAP_LOADED_SUFFIX.format(pcap_file=pcap_file)
@@ -48,6 +49,7 @@ def create_agent(
         ingest_pcap,
         get_protocol_breakdown,
         get_top_talkers,
+        get_layer2_summary,
         query,
         detect_port_scans,
         detect_anomalies,

--- a/src/pcap_agent/tools/layer2.py
+++ b/src/pcap_agent/tools/layer2.py
@@ -24,10 +24,7 @@ def get_layer2_summary() -> dict:
     if eth_count == 0:
         return {
             "error": "No Ethernet frame data found",
-            "hint": (
-                "This capture may use a non-Ethernet link type,"
-                " or no PCAP has been ingested yet."
-            ),
+            "hint": "This capture may use a non-Ethernet link type.",
         }
 
     ci = conn.execute(
@@ -63,10 +60,12 @@ def get_layer2_summary() -> dict:
         " GROUP BY dst_mac ORDER BY cnt DESC LIMIT 5"
     ).fetchall()
 
+    total_count = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+
     result = {
         "link_type": link_type,
         "has_radiotap": has_radiotap,
-        "total_frame_count": eth_count,
+        "total_frame_count": total_count,
         "ethernet_frame_count": eth_count,
         "arp_request_count": arp_by_op.get(1, 0),
         "arp_reply_count": arp_by_op.get(2, 0),

--- a/src/pcap_agent/tools/layer2.py
+++ b/src/pcap_agent/tools/layer2.py
@@ -1,0 +1,80 @@
+"""Layer 2 summary tool: link type, Ethernet, ARP, and MAC statistics."""
+
+import logging
+
+from pcap_agent.tools import _state
+
+logger = logging.getLogger(__name__)
+
+
+def get_layer2_summary() -> dict:
+    """Return L2 statistics for the ingested capture.
+
+    Fields: link_type, has_radiotap, total_frame_count, ethernet_frame_count,
+    arp_request_count, arp_reply_count, unique_src_mac_count,
+    unique_dst_mac_count, distinct_vlan_ids, top_5_src_macs, top_5_dst_macs.
+
+    Returns {"error": ..., "hint": ...} when no ethernet_frames rows exist.
+    """
+    conn = _state.require_connection()
+
+    eth_count = conn.execute(
+        "SELECT COUNT(*) FROM ethernet_frames"
+    ).fetchone()[0]
+    if eth_count == 0:
+        return {
+            "error": "No Ethernet frame data found",
+            "hint": (
+                "This capture may use a non-Ethernet link type,"
+                " or no PCAP has been ingested yet."
+            ),
+        }
+
+    ci = conn.execute(
+        "SELECT link_type, has_radiotap FROM capture_info LIMIT 1"
+    ).fetchone()
+    link_type = ci[0] if ci else None
+    has_radiotap = ci[1] if ci else False
+
+    arp_counts = conn.execute(
+        "SELECT operation, COUNT(*) FROM arp_packets GROUP BY operation"
+    ).fetchall()
+    arp_by_op = {op: cnt for op, cnt in arp_counts}
+
+    unique_src = conn.execute(
+        "SELECT COUNT(DISTINCT src_mac) FROM ethernet_frames"
+    ).fetchone()[0]
+    unique_dst = conn.execute(
+        "SELECT COUNT(DISTINCT dst_mac) FROM ethernet_frames"
+    ).fetchone()[0]
+
+    vlan_rows = conn.execute(
+        "SELECT DISTINCT vlan_id FROM ethernet_frames"
+        " WHERE vlan_id IS NOT NULL ORDER BY vlan_id"
+    ).fetchall()
+    distinct_vlan_ids = [r[0] for r in vlan_rows]
+
+    top_src = conn.execute(
+        "SELECT src_mac, COUNT(*) AS cnt FROM ethernet_frames"
+        " GROUP BY src_mac ORDER BY cnt DESC LIMIT 5"
+    ).fetchall()
+    top_dst = conn.execute(
+        "SELECT dst_mac, COUNT(*) AS cnt FROM ethernet_frames"
+        " GROUP BY dst_mac ORDER BY cnt DESC LIMIT 5"
+    ).fetchall()
+
+    result = {
+        "link_type": link_type,
+        "has_radiotap": has_radiotap,
+        "total_frame_count": eth_count,
+        "ethernet_frame_count": eth_count,
+        "arp_request_count": arp_by_op.get(1, 0),
+        "arp_reply_count": arp_by_op.get(2, 0),
+        "unique_src_mac_count": unique_src,
+        "unique_dst_mac_count": unique_dst,
+        "distinct_vlan_ids": distinct_vlan_ids,
+        "top_5_src_macs": [{"mac": r[0], "count": r[1]} for r in top_src],
+        "top_5_dst_macs": [{"mac": r[0], "count": r[1]} for r in top_dst],
+    }
+    logger.debug("get_layer2_summary: %d ethernet frames", eth_count)
+    return result

--- a/src/pcap_agent/tools/layer2.py
+++ b/src/pcap_agent/tools/layer2.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def get_layer2_summary() -> dict:
     """Return L2 statistics for the ingested capture.
 
-    Fields: link_type, has_radiotap, total_frame_count, ethernet_frame_count,
+    Fields: link_type, has_radiotap, ethernet_frame_count, ip_packet_count,
     arp_request_count, arp_reply_count, unique_src_mac_count,
     unique_dst_mac_count, distinct_vlan_ids, top_5_src_macs, top_5_dst_macs.
 
@@ -60,13 +60,13 @@ def get_layer2_summary() -> dict:
         " GROUP BY dst_mac ORDER BY cnt DESC LIMIT 5"
     ).fetchall()
 
-    total_count = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
+    ip_count = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
 
     result = {
         "link_type": link_type,
         "has_radiotap": has_radiotap,
-        "total_frame_count": total_count,
         "ethernet_frame_count": eth_count,
+        "ip_packet_count": ip_count,
         "arp_request_count": arp_by_op.get(1, 0),
         "arp_reply_count": arp_by_op.get(2, 0),
         "unique_src_mac_count": unique_src,

--- a/tests/test_layer2_tool.py
+++ b/tests/test_layer2_tool.py
@@ -118,9 +118,9 @@ class TestGetLayer2SummaryEthernetCapture:
         result = get_layer2_summary()
         assert result["has_radiotap"] is False
 
-    def test_total_frame_count(self, eth_conn):
+    def test_ip_packet_count(self, eth_conn):
         result = get_layer2_summary()
-        assert result["total_frame_count"] == _IP_FRAME_COUNT
+        assert result["ip_packet_count"] == _IP_FRAME_COUNT
 
     def test_ethernet_frame_count(self, eth_conn):
         result = get_layer2_summary()
@@ -173,8 +173,8 @@ class TestGetLayer2SummaryEthernetCapture:
         expected_keys = {
             "link_type",
             "has_radiotap",
-            "total_frame_count",
             "ethernet_frame_count",
+            "ip_packet_count",
             "arp_request_count",
             "arp_reply_count",
             "unique_src_mac_count",

--- a/tests/test_layer2_tool.py
+++ b/tests/test_layer2_tool.py
@@ -1,0 +1,197 @@
+"""Integration tests for tools.layer2: get_layer2_summary."""
+
+import duckdb
+import pytest
+from scapy.all import (  # type: ignore[import-untyped]
+    ARP,
+    IP,
+    TCP,
+    UDP,
+    Dot1Q,
+    Ether,
+    Raw,
+    wrpcap,
+)
+
+from pcap_agent import db
+from pcap_agent.tools import _state
+from pcap_agent.tools.layer2 import get_layer2_summary
+
+_ETH_SRC_A = "aa:bb:cc:dd:ee:01"
+_ETH_DST_A = "11:22:33:44:55:01"
+_ARP_SRC_MAC = "aa:bb:cc:dd:ee:02"
+_ARP_DST_MAC = "ff:ff:ff:ff:ff:ff"
+_ARP_REP_SRC = "aa:bb:cc:dd:ee:03"
+_ARP_REP_DST = "aa:bb:cc:dd:ee:02"
+_ARP_SRC_IP = "192.168.10.1"
+_ARP_DST_IP = "192.168.10.2"
+_VLAN_ID = 100
+_ETH_IP_SRC = "10.20.0.1"
+_ETH_IP_DST = "10.20.0.2"
+_VLAN_IP_SRC = "10.30.0.1"
+_VLAN_IP_DST = "10.30.0.2"
+
+_ETH_FRAME_COUNT = 4
+_ARP_REQUEST_COUNT = 1
+_ARP_REPLY_COUNT = 1
+_UNIQUE_SRC_MACS = 3  # _ETH_SRC_A (x2), _ARP_SRC_MAC, _ARP_REP_SRC
+_UNIQUE_DST_MACS = 3  # _ETH_DST_A (x2), _ARP_DST_MAC, _ARP_REP_DST
+_LINK_TYPE_ETHERNET = 1
+
+
+@pytest.fixture(scope="class")
+def eth_pcap(tmp_path_factory):
+    """Write a small Ethernet PCAP with ARP and VLAN frames."""
+    tmp_path = tmp_path_factory.mktemp("eth_l2")
+    pcap_path = tmp_path / "ethernet.pcap"
+    pkts = [
+        Ether(src=_ETH_SRC_A, dst=_ETH_DST_A)
+        / IP(src=_ETH_IP_SRC, dst=_ETH_IP_DST)
+        / UDP(sport=1234, dport=5678)
+        / Raw(load=b"hello"),
+        Ether(src=_ARP_SRC_MAC, dst=_ARP_DST_MAC)
+        / ARP(
+            op=1,
+            hwsrc=_ARP_SRC_MAC,
+            psrc=_ARP_SRC_IP,
+            hwdst=_ARP_DST_MAC,
+            pdst=_ARP_DST_IP,
+        ),
+        Ether(src=_ARP_REP_SRC, dst=_ARP_REP_DST)
+        / ARP(
+            op=2,
+            hwsrc=_ARP_REP_SRC,
+            psrc=_ARP_DST_IP,
+            hwdst=_ARP_REP_DST,
+            pdst=_ARP_SRC_IP,
+        ),
+        Ether(src=_ETH_SRC_A, dst=_ETH_DST_A)
+        / Dot1Q(vlan=_VLAN_ID)
+        / IP(src=_VLAN_IP_SRC, dst=_VLAN_IP_DST)
+        / TCP(sport=9000, dport=80, flags="S"),
+    ]
+    wrpcap(str(pcap_path), pkts)
+    return pcap_path
+
+
+@pytest.fixture()
+def eth_conn(eth_pcap):
+    """Ingest the Ethernet PCAP into an in-memory DB and set the _state singleton."""
+    from pcap_agent import parser
+
+    conn = duckdb.connect(":memory:")
+    db.create_schema(conn)
+    parsed = parser.parse(eth_pcap)
+    db.ingest(conn, parsed)
+    db.set_capture_info(
+        conn,
+        sha256="test-sha256",
+        link_type=parsed.link_type,
+        has_radiotap=parsed.has_radiotap,
+        signal_dbm=parsed.signal_dbm,
+        channel=parsed.channel,
+        data_rate_mbps=parsed.data_rate_mbps,
+    )
+    old = _state.get_connection()
+    old_path = _state.get_db_path()
+    _state.set_connection(conn, ":memory:")
+    yield conn
+    _state.set_connection(old, old_path) if old else _state.reset()
+    conn.close()
+
+
+class TestGetLayer2SummaryEthernetCapture:
+    def test_returns_dict(self, eth_conn):
+        result = get_layer2_summary()
+        assert isinstance(result, dict)
+
+    def test_no_error_key(self, eth_conn):
+        result = get_layer2_summary()
+        assert "error" not in result
+
+    def test_link_type(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["link_type"] == _LINK_TYPE_ETHERNET
+
+    def test_has_radiotap_false(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["has_radiotap"] is False
+
+    def test_total_frame_count(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["total_frame_count"] == _ETH_FRAME_COUNT
+
+    def test_ethernet_frame_count(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["ethernet_frame_count"] == _ETH_FRAME_COUNT
+
+    def test_arp_request_count(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["arp_request_count"] == _ARP_REQUEST_COUNT
+
+    def test_arp_reply_count(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["arp_reply_count"] == _ARP_REPLY_COUNT
+
+    def test_unique_src_mac_count(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["unique_src_mac_count"] == _UNIQUE_SRC_MACS
+
+    def test_unique_dst_mac_count(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["unique_dst_mac_count"] == _UNIQUE_DST_MACS
+
+    def test_distinct_vlan_ids(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["distinct_vlan_ids"] == [_VLAN_ID]
+
+    def test_top_5_src_macs_structure(self, eth_conn):
+        result = get_layer2_summary()
+        assert isinstance(result["top_5_src_macs"], list)
+        assert all("mac" in r and "count" in r for r in result["top_5_src_macs"])
+
+    def test_top_5_dst_macs_structure(self, eth_conn):
+        result = get_layer2_summary()
+        assert isinstance(result["top_5_dst_macs"], list)
+        assert all("mac" in r and "count" in r for r in result["top_5_dst_macs"])
+
+    def test_top_src_mac_is_most_frequent(self, eth_conn):
+        result = get_layer2_summary()
+        # _ETH_SRC_A appears in frames 0 and 3 (count=2)
+        assert result["top_5_src_macs"][0]["mac"] == _ETH_SRC_A
+        assert result["top_5_src_macs"][0]["count"] == 2
+
+    def test_top_dst_mac_is_most_frequent(self, eth_conn):
+        result = get_layer2_summary()
+        # _ETH_DST_A appears in frames 0 and 3 (count=2)
+        assert result["top_5_dst_macs"][0]["mac"] == _ETH_DST_A
+        assert result["top_5_dst_macs"][0]["count"] == 2
+
+    def test_result_keys(self, eth_conn):
+        result = get_layer2_summary()
+        expected_keys = {
+            "link_type",
+            "has_radiotap",
+            "total_frame_count",
+            "ethernet_frame_count",
+            "arp_request_count",
+            "arp_reply_count",
+            "unique_src_mac_count",
+            "unique_dst_mac_count",
+            "distinct_vlan_ids",
+            "top_5_src_macs",
+            "top_5_dst_macs",
+        }
+        assert set(result.keys()) == expected_keys
+
+
+class TestGetLayer2SummaryNoEthernetData:
+    def test_returns_error_when_no_ethernet_frames(self, ingested_db):
+        # The synthetic PCAP uses raw IP (no Ether layer), so ethernet_frames is empty.
+        result = get_layer2_summary()
+        assert "error" in result
+        assert "hint" in result
+
+    def test_error_message_mentions_ethernet(self, ingested_db):
+        result = get_layer2_summary()
+        assert "Ethernet" in result["error"] or "ethernet" in result["error"].lower()

--- a/tests/test_layer2_tool.py
+++ b/tests/test_layer2_tool.py
@@ -32,6 +32,7 @@ _VLAN_IP_SRC = "10.30.0.1"
 _VLAN_IP_DST = "10.30.0.2"
 
 _ETH_FRAME_COUNT = 4
+_IP_FRAME_COUNT = 2  # only IP-bearing frames land in the packets table
 _ARP_REQUEST_COUNT = 1
 _ARP_REPLY_COUNT = 1
 _UNIQUE_SRC_MACS = 3  # _ETH_SRC_A (x2), _ARP_SRC_MAC, _ARP_REP_SRC
@@ -119,7 +120,7 @@ class TestGetLayer2SummaryEthernetCapture:
 
     def test_total_frame_count(self, eth_conn):
         result = get_layer2_summary()
-        assert result["total_frame_count"] == _ETH_FRAME_COUNT
+        assert result["total_frame_count"] == _IP_FRAME_COUNT
 
     def test_ethernet_frame_count(self, eth_conn):
         result = get_layer2_summary()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -35,6 +35,7 @@ class TestAgentLogging:
             "ingest_pcap",
             "get_protocol_breakdown",
             "get_top_talkers",
+            "get_layer2_summary",
             "query",
             "detect_port_scans",
             "detect_anomalies",
@@ -43,7 +44,7 @@ class TestAgentLogging:
         for tool_name in expected_tools:
             assert any(tool_name in msg for msg in debug_msgs)
 
-    def test_seven_tool_registrations_logged(self, caplog):
+    def test_eight_tool_registrations_logged(self, caplog):
         from pcap_agent.agent import create_agent
 
         with caplog.at_level(logging.DEBUG, logger="pcap_agent.agent"):
@@ -53,7 +54,7 @@ class TestAgentLogging:
             r for r in caplog.records
             if r.levelno == logging.DEBUG and r.name == "pcap_agent.agent"
         ]
-        assert len(debug_msgs) == 7
+        assert len(debug_msgs) == 8
 
     def test_logger_uses_module_name(self):
         import pcap_agent.agent as agent_mod


### PR DESCRIPTION
## Summary

Adds a `get_layer2_summary()` tool that queries the current DuckDB connection
and returns Layer 2 statistics for the ingested capture: link type, radiotap
flag, Ethernet frame count, IP packet count, ARP request/reply counts, unique
source/destination MAC counts, distinct VLAN IDs, and top-5 source/destination
MACs by frame count.

Returns `{"error": ..., "hint": ...}` for non-Ethernet captures (no rows in
`ethernet_frames`), following the existing tool error convention.

Closes #43

## Changes

- `src/pcap_agent/tools/layer2.py`: new `get_layer2_summary()` tool
- `src/pcap_agent/agent.py`: registers `get_layer2_summary` as the 8th tool
- `tests/test_layer2_tool.py`: 18 integration tests covering Ethernet success path and no-data error path
- `tests/test_logging.py`: updated to expect 8 tool registrations

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | `get_layer2_summary()` in `src/pcap_agent/tools/layer2.py` | Yes | `layer2.py` created |
| 2 | Returns all specified fields for an Ethernet capture | Yes | `test_result_keys`, `test_link_type`, `test_ethernet_frame_count`, etc. |
| 3 | Returns `{"error": ..., "hint": ...}` when no `ethernet_frames` rows exist | Yes | `TestGetLayer2SummaryNoEthernetData::test_returns_error_when_no_ethernet_frames` |
| 4 | Registered in `agent.py` alongside existing tools | Yes | `agent.py` updated; `test_eight_tool_registrations_logged` confirms 8 registrations |
| 5 | Integration tests use `ingested_db` session fixture | Yes | `TestGetLayer2SummaryNoEthernetData` uses `ingested_db`; Ethernet tests use custom `eth_conn` fixture |
| 6 | `ruff check` and `uv run pytest` pass | Yes | 232/232 tests pass, ruff clean |

## Testing

```bash
uv run pytest tests/test_layer2_tool.py -v
uv run pytest
```
