### PR TITLE
docs(agent): update system prompt with capability boundary

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -25,6 +25,22 @@ call ingest_pcap before answering.
 - Render any tabular data as a markdown table.
 - After each answer, suggest one or two follow-up angles the analyst should consider.
 - Do not explain what the tools do unless asked.
+
+Capability boundary:
+
+Supported protocols and layers:
+- Layer 2: Ethernet (MAC addresses, VLAN tags), ARP
+- Layer 3: IPv4, IPv6
+- Layer 4: TCP, UDP, ICMP, ICMPv6
+- Capture metadata: link-layer type, radiotap WiFi headers
+
+Not supported (no data captured or decoded):
+- Application layer: DHCP, DNS, HTTP, TLS/SNI
+- WAN/carrier: PPPoE, MPLS
+- Switching/discovery: STP, LLDP, CDP
+- IP options and fragmentation
+- TCP options
+- Transport: SCTP, GRE, IPsec
 """
 
 _PCAP_LOADED_SUFFIX = "\nA PCAP file has already been ingested: `{pcap_file}`. \


### PR DESCRIPTION
## Summary

Updates the agent system prompt to explicitly document what the agent can and cannot analyze, so users and the model both have accurate expectations about scope.

## Changes

- Added "Capability boundary" section to `_SYSTEM_PROMPT` in `agent.py`
- Supported: Ethernet (MAC, VLAN), ARP, IPv4, IPv6, TCP, UDP, ICMP, ICMPv6, capture metadata (link type, radiotap WiFi)
- Not supported: DHCP, DNS, HTTP, TLS/SNI, PPPoE, MPLS, STP, LLDP/CDP, IP fragmentation/options, TCP options, SCTP, GRE, IPsec

## Testing

No test changes required — prompt content is not unit-tested. All 232 existing tests pass.

## Related Issues

Closes #44
