### PR TITLE
refactor(schema): slim capture_info DDL and add radiotap_frames table

### DIFF
--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -75,7 +75,11 @@ CREATE TABLE IF NOT EXISTS pcap_meta (
 CREATE TABLE IF NOT EXISTS capture_info (
     sha256          VARCHAR PRIMARY KEY,
     link_type       INTEGER,
-    has_radiotap    BOOLEAN,
+    has_radiotap    BOOLEAN
+);
+
+CREATE TABLE IF NOT EXISTS radiotap_frames (
+    frame_id        BIGINT PRIMARY KEY,
     signal_dbm      DOUBLE,
     channel         INTEGER,
     data_rate_mbps  DOUBLE
@@ -137,22 +141,16 @@ def set_capture_info(
     sha256: str,
     link_type: int,
     has_radiotap: bool,
-    signal_dbm: float | None,
-    channel: int | None,
-    data_rate_mbps: float | None,
 ) -> None:
     """Insert or replace the capture_info row for sha256."""
     conn.execute(
         "INSERT INTO capture_info"
-        " (sha256, link_type, has_radiotap, signal_dbm, channel, data_rate_mbps)"
-        " VALUES (?, ?, ?, ?, ?, ?)"
+        " (sha256, link_type, has_radiotap)"
+        " VALUES (?, ?, ?)"
         " ON CONFLICT (sha256) DO UPDATE SET"
         "   link_type = EXCLUDED.link_type,"
-        "   has_radiotap = EXCLUDED.has_radiotap,"
-        "   signal_dbm = EXCLUDED.signal_dbm,"
-        "   channel = EXCLUDED.channel,"
-        "   data_rate_mbps = EXCLUDED.data_rate_mbps",
-        [sha256, link_type, has_radiotap, signal_dbm, channel, data_rate_mbps],
+        "   has_radiotap = EXCLUDED.has_radiotap",
+        [sha256, link_type, has_radiotap],
     )
 
 
@@ -167,7 +165,7 @@ def set_cached(
     )
 
 
-_REQUIRED_TABLES = {"ethernet_frames", "arp_packets", "capture_info"}
+_REQUIRED_TABLES = {"ethernet_frames", "arp_packets", "capture_info", "radiotap_frames"}
 
 _DATA_TABLES = [
     "packets",
@@ -177,6 +175,7 @@ _DATA_TABLES = [
     "ethernet_frames",
     "arp_packets",
     "capture_info",
+    "radiotap_frames",
     "pcap_meta",
 ]
 

--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -116,6 +116,7 @@ def ingest(
         _load_df(conn, "icmp_messages", frames.icmp_messages)
         _load_df(conn, "ethernet_frames", frames.ethernet_frames)
         _load_df(conn, "arp_packets", frames.arp_packets)
+        _load_df(conn, "radiotap_frames", frames.radiotap_frames)
         if begin_transaction:
             conn.commit()
     except Exception:

--- a/src/pcap_agent/parser.py
+++ b/src/pcap_agent/parser.py
@@ -78,6 +78,13 @@ _ARP_PACKETS_SCHEMA = {
     "target_ip": pl.String,
 }
 
+_RADIOTAP_FRAMES_SCHEMA = {
+    "frame_id": pl.Int64,
+    "signal_dbm": pl.Float64,
+    "channel": pl.Int32,
+    "data_rate_mbps": pl.Float64,
+}
+
 
 @dataclass(frozen=True)
 class ParsedPcap:
@@ -87,11 +94,9 @@ class ParsedPcap:
     icmp_messages: pl.DataFrame
     ethernet_frames: pl.DataFrame
     arp_packets: pl.DataFrame
+    radiotap_frames: pl.DataFrame
     link_type: int
     has_radiotap: bool
-    signal_dbm: float | None
-    channel: int | None
-    data_rate_mbps: float | None
 
 
 def _freq_to_channel(freq_mhz: int) -> int | None:
@@ -112,29 +117,30 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
         raw_packets = reader.read_all()
 
     has_radiotap = False
-    signal_dbm: float | None = None
-    channel: int | None = None
-    data_rate_mbps: float | None = None
-    for pkt in raw_packets:
-        if pkt.haslayer(RadioTap):
-            has_radiotap = True
-            rt = pkt[RadioTap]
-            sig = getattr(rt, "dBm_AntSignal", None)
-            freq = getattr(rt, "ChannelFrequency", None)
-            rate = getattr(rt, "Rate", None)
-            signal_dbm = float(sig) if sig is not None else None
-            channel = _freq_to_channel(freq) if freq is not None else None
-            data_rate_mbps = float(rate) / 2.0 if rate is not None else None
-            break
-
     packets_rows: list[dict] = []
     tcp_rows: list[dict] = []
     udp_rows: list[dict] = []
     icmp_rows: list[dict] = []
     ethernet_rows: list[dict] = []
     arp_rows: list[dict] = []
+    radiotap_rows: list[dict] = []
 
     for frame_id, pkt in enumerate(raw_packets):
+        if pkt.haslayer(RadioTap):
+            has_radiotap = True
+            rt = pkt[RadioTap]
+            sig = getattr(rt, "dBm_AntSignal", None)
+            freq = getattr(rt, "ChannelFrequency", None)
+            rate = getattr(rt, "Rate", None)
+            radiotap_rows.append(
+                {
+                    "frame_id": frame_id,
+                    "signal_dbm": float(sig) if sig is not None else None,
+                    "channel": _freq_to_channel(freq) if freq is not None else None,
+                    "data_rate_mbps": float(rate) / 2.0 if rate is not None else None,
+                }
+            )
+
         if pkt.haslayer(Ether):
             ether = pkt[Ether]
             if pkt.haslayer(Dot1Q):
@@ -282,9 +288,9 @@ def parse(pcap_path: Path | str) -> ParsedPcap:
         arp_packets=pl.DataFrame(arp_rows, schema=_ARP_PACKETS_SCHEMA)
         if arp_rows
         else pl.DataFrame(schema=_ARP_PACKETS_SCHEMA),
+        radiotap_frames=pl.DataFrame(radiotap_rows, schema=_RADIOTAP_FRAMES_SCHEMA)
+        if radiotap_rows
+        else pl.DataFrame(schema=_RADIOTAP_FRAMES_SCHEMA),
         link_type=link_type,
         has_radiotap=has_radiotap,
-        signal_dbm=signal_dbm,
-        channel=channel,
-        data_rate_mbps=data_rate_mbps,
     )

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -79,9 +79,6 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
             sha256,
             frames.link_type,
             frames.has_radiotap,
-            frames.signal_dbm,
-            frames.channel,
-            frames.data_rate_mbps,
         )
         conn.commit()
     except Exception:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -20,6 +20,7 @@ _EXPECTED_TABLES = {
     "arp_packets",
     "pcap_meta",
     "capture_info",
+    "radiotap_frames",
 }
 
 
@@ -139,61 +140,37 @@ class TestSetCaptureInfo:
     _SHA256 = "d" * 64
 
     def test_inserts_row(self, duckdb_conn):
-        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False)
         row = duckdb_conn.execute(
-            "SELECT link_type, has_radiotap, signal_dbm, channel, data_rate_mbps"
-            " FROM capture_info WHERE sha256 = ?",
+            "SELECT link_type, has_radiotap FROM capture_info WHERE sha256 = ?",
             [self._SHA256],
         ).fetchone()
         assert row is not None
         assert row[0] == 1
         assert row[1] is False
-        assert row[2] is None
-        assert row[3] is None
-        assert row[4] is None
-
-    def test_non_radiotap_wifi_columns_null(self, duckdb_conn):
-        db.set_capture_info(duckdb_conn, self._SHA256, 228, False, None, None, None)
-        row = duckdb_conn.execute(
-            "SELECT has_radiotap, signal_dbm, channel, data_rate_mbps"
-            " FROM capture_info WHERE sha256 = ?",
-            [self._SHA256],
-        ).fetchone()
-        assert row[0] is False
-        assert row[1] is None
-        assert row[2] is None
-        assert row[3] is None
 
     def test_radiotap_row(self, duckdb_conn):
-        db.set_capture_info(duckdb_conn, self._SHA256, 127, True, -65.0, 6, 54.0)
+        db.set_capture_info(duckdb_conn, self._SHA256, 127, True)
         row = duckdb_conn.execute(
-            "SELECT link_type, has_radiotap, signal_dbm, channel, data_rate_mbps"
-            " FROM capture_info WHERE sha256 = ?",
+            "SELECT link_type, has_radiotap FROM capture_info WHERE sha256 = ?",
             [self._SHA256],
         ).fetchone()
         assert row[0] == 127
         assert row[1] is True
-        assert row[2] == -65.0
-        assert row[3] == 6
-        assert row[4] == 54.0
 
     def test_upsert_updates_existing_row(self, duckdb_conn):
-        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
-        db.set_capture_info(duckdb_conn, self._SHA256, 127, True, -70.0, 11, 24.0)
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False)
+        db.set_capture_info(duckdb_conn, self._SHA256, 127, True)
         row = duckdb_conn.execute(
-            "SELECT link_type, has_radiotap, signal_dbm, channel, data_rate_mbps"
-            " FROM capture_info WHERE sha256 = ?",
+            "SELECT link_type, has_radiotap FROM capture_info WHERE sha256 = ?",
             [self._SHA256],
         ).fetchone()
         assert row[0] == 127
         assert row[1] is True
-        assert row[2] == -70.0
-        assert row[3] == 11
-        assert row[4] == 24.0
 
     def test_only_one_row_per_sha256(self, duckdb_conn):
-        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
-        db.set_capture_info(duckdb_conn, self._SHA256, 1, False, None, None, None)
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False)
+        db.set_capture_info(duckdb_conn, self._SHA256, 1, False)
         count = duckdb_conn.execute(
             "SELECT COUNT(*) FROM capture_info WHERE sha256 = ?", [self._SHA256]
         ).fetchone()[0]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -200,3 +200,21 @@ class TestGetCached:
         self._insert(duckdb_conn)
         result = db.get_cached(duckdb_conn, "b" * 64)
         assert result is None
+
+
+class TestRadiotapFrames:
+    def test_table_empty_for_non_radiotap_capture(self, ingested_conn):
+        count = ingested_conn.execute(
+            "SELECT COUNT(*) FROM radiotap_frames"
+        ).fetchone()[0]
+        assert count == 0
+
+    def test_schema_has_expected_columns(self, duckdb_conn):
+        cols = {
+            row[0]
+            for row in duckdb_conn.execute(
+                "SELECT column_name FROM information_schema.columns"
+                " WHERE table_name = 'radiotap_frames'"
+            ).fetchall()
+        }
+        assert cols == {"frame_id", "signal_dbm", "channel", "data_rate_mbps"}

--- a/tests/test_layer2_tool.py
+++ b/tests/test_layer2_tool.py
@@ -89,9 +89,6 @@ def eth_conn(eth_pcap):
         sha256="test-sha256",
         link_type=parsed.link_type,
         has_radiotap=parsed.has_radiotap,
-        signal_dbm=parsed.signal_dbm,
-        channel=parsed.channel,
-        data_rate_mbps=parsed.data_rate_mbps,
     )
     old = _state.get_connection()
     old_path = _state.get_db_path()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -436,10 +436,8 @@ class TestEthernetParsing:
     def test_has_radiotap_false_for_ethernet(self, parsed_eth):
         assert parsed_eth.has_radiotap is False
 
-    def test_wifi_fields_null_for_ethernet(self, parsed_eth):
-        assert parsed_eth.signal_dbm is None
-        assert parsed_eth.channel is None
-        assert parsed_eth.data_rate_mbps is None
+    def test_radiotap_frames_empty_for_ethernet(self, parsed_eth):
+        assert parsed_eth.radiotap_frames.is_empty()
 
 
 _RT_SIGNAL_DBM = -65
@@ -481,14 +479,17 @@ class TestRadiotapParsing:
     def test_has_radiotap_true(self, parsed_rt):
         assert parsed_rt.has_radiotap is True
 
+    def test_radiotap_frames_row_count(self, parsed_rt):
+        assert len(parsed_rt.radiotap_frames) == 1
+
     def test_signal_dbm(self, parsed_rt):
-        assert parsed_rt.signal_dbm == float(_RT_SIGNAL_DBM)
+        assert parsed_rt.radiotap_frames["signal_dbm"][0] == float(_RT_SIGNAL_DBM)
 
     def test_channel(self, parsed_rt):
-        assert parsed_rt.channel == _RT_EXPECTED_CHANNEL
+        assert parsed_rt.radiotap_frames["channel"][0] == _RT_EXPECTED_CHANNEL
 
     def test_data_rate_mbps(self, parsed_rt):
-        assert parsed_rt.data_rate_mbps == _RT_EXPECTED_RATE_MBPS
+        assert parsed_rt.radiotap_frames["data_rate_mbps"][0] == _RT_EXPECTED_RATE_MBPS
 
 
 class TestRawIpLinkType:
@@ -498,7 +499,5 @@ class TestRawIpLinkType:
     def test_has_radiotap_false(self, parsed_pcap):
         assert parsed_pcap.has_radiotap is False
 
-    def test_wifi_fields_null(self, parsed_pcap):
-        assert parsed_pcap.signal_dbm is None
-        assert parsed_pcap.channel is None
-        assert parsed_pcap.data_rate_mbps is None
+    def test_radiotap_frames_empty(self, parsed_pcap):
+        assert parsed_pcap.radiotap_frames.is_empty()


### PR DESCRIPTION
## Summary

Moves radiotap data out of the capture-level `capture_info` table into a new `radiotap_frames` table keyed by `frame_id`. Capture-level metadata (`sha256`, `link_type`, `has_radiotap`) stays in `capture_info`; per-frame radio metrics (`signal_dbm`, `channel`, `data_rate_mbps`) move to `radiotap_frames`. The parser loop now collects one row per radiotap frame instead of sampling only the first.

## Changes

- `capture_info` DDL: drop `signal_dbm`, `channel`, `data_rate_mbps`
- Add `radiotap_frames (frame_id BIGINT PK, signal_dbm DOUBLE, channel INTEGER, data_rate_mbps DOUBLE)` to DDL
- `set_capture_info()`: remove the three radio parameters
- `_REQUIRED_TABLES` / `_DATA_TABLES`: add `radiotap_frames` so `is_schema_stale()` detects a missing table
- `parser.py`: replace first-frame-only radiotap sampling with per-frame collection; remove dead `signal_dbm`/`channel`/`data_rate_mbps` fields from `ParsedPcap`; add `radiotap_frames: pl.DataFrame`
- `ingest()`: wire in `_load_df(conn, "radiotap_frames", ...)`
- Tests: update `TestSetCaptureInfo`, `TestRadiotapParsing`, `TestRawIpLinkType`; add `TestRadiotapFrames`

## Testing

All 234 tests pass (`uv run pytest`). Branch review passed roborev with no findings.

## Related Issues

Closes #52