### PR TITLE
feat(tools,schema): update get_layer2_summary() and schema injection for radiotap_frames

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -46,9 +46,6 @@ Not supported (no data captured or decoded):
 _PCAP_LOADED_SUFFIX = "\nA PCAP file has already been ingested: `{pcap_file}`. \
 The data is ready for analysis."
 
-_SCHEMA_SUFFIX = "\n\n{schema}"
-
-
 def create_agent(
     *, api_key: str, model: str, pcap_file: str | None = None, schema: str | None = None
 ) -> "ChatAnthropic":
@@ -57,7 +54,7 @@ def create_agent(
     if pcap_file:
         system_prompt += _PCAP_LOADED_SUFFIX.format(pcap_file=pcap_file)
     if schema:
-        system_prompt += _SCHEMA_SUFFIX.format(schema=schema)
+        system_prompt += "\n\n" + schema
 
     chat = ChatAnthropic(
         system_prompt=system_prompt,

--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -46,14 +46,18 @@ Not supported (no data captured or decoded):
 _PCAP_LOADED_SUFFIX = "\nA PCAP file has already been ingested: `{pcap_file}`. \
 The data is ready for analysis."
 
+_SCHEMA_SUFFIX = "\n\n{schema}"
+
 
 def create_agent(
-    *, api_key: str, model: str, pcap_file: str | None = None
+    *, api_key: str, model: str, pcap_file: str | None = None, schema: str | None = None
 ) -> "ChatAnthropic":
     """Return a ChatAnthropic session with all 8 analysis tools registered."""
     system_prompt = _SYSTEM_PROMPT
     if pcap_file:
         system_prompt += _PCAP_LOADED_SUFFIX.format(pcap_file=pcap_file)
+    if schema:
+        system_prompt += _SCHEMA_SUFFIX.format(schema=schema)
 
     chat = ChatAnthropic(
         system_prompt=system_prompt,

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -122,6 +122,7 @@ def main(
         click.echo(f"Error: cannot open log file: {exc}", err=True)
         sys.exit(1)
 
+    schema: str | None = None
     if pcap_file:
         from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -138,10 +139,13 @@ def main(
             click.echo("Warning: no packets were ingested from the file.", err=True)
         else:
             _print_synopsis(pcap_file, result)
+        schema = result.get("schema")
 
     from pcap_agent.agent import create_agent
 
-    chat = create_agent(api_key=api_key, model=model, pcap_file=pcap_file)
+    chat = create_agent(
+        api_key=api_key, model=model, pcap_file=pcap_file, schema=schema
+    )
 
     if ui == "app":
         chat.app()

--- a/src/pcap_agent/db.py
+++ b/src/pcap_agent/db.py
@@ -181,6 +181,34 @@ _DATA_TABLES = [
 ]
 
 
+_SCHEMA_EXCLUDED_TABLES = frozenset({"pcap_meta", "capture_info"})
+
+
+def get_schema(conn: duckdb.DuckDBPyConnection) -> str:
+    """Return a compact schema string for all analysis-facing tables.
+
+    pcap_meta and capture_info are excluded as internal tables.
+    Columns follow ordinal_position within each table.
+    """
+    rows = conn.execute(
+        "SELECT table_name, column_name, data_type"
+        " FROM information_schema.columns"
+        " WHERE table_schema = 'main'"
+        " ORDER BY table_name, ordinal_position"
+    ).fetchall()
+
+    tables: dict[str, list[str]] = {}
+    for table_name, column_name, data_type in rows:
+        if table_name in _SCHEMA_EXCLUDED_TABLES:
+            continue
+        tables.setdefault(table_name, []).append(f"{column_name} {data_type}")
+
+    lines = ["Database schema:"]
+    for table_name, cols in sorted(tables.items()):
+        lines.append(f"  {table_name}: {', '.join(cols)}")
+    return "\n".join(lines)
+
+
 def is_schema_stale(conn: duckdb.DuckDBPyConnection) -> bool:
     """Return True if any of the new tables are missing from the database."""
     rows = conn.execute(

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -112,6 +112,7 @@ def _summary(
         "protocol_counts": get_protocol_breakdown(),
         "top_talkers": get_top_talkers(10),
         "db_path": db_path,
+        "schema": db.get_schema(conn),
     }
 
 

--- a/src/pcap_agent/tools/layer2.py
+++ b/src/pcap_agent/tools/layer2.py
@@ -12,7 +12,9 @@ def get_layer2_summary() -> dict:
 
     Fields: link_type, has_radiotap, ethernet_frame_count, ip_packet_count,
     arp_request_count, arp_reply_count, unique_src_mac_count,
-    unique_dst_mac_count, distinct_vlan_ids, top_5_src_macs, top_5_dst_macs.
+    unique_dst_mac_count, distinct_vlan_ids, top_5_src_macs, top_5_dst_macs,
+    avg_signal_dbm, min_signal_dbm, max_signal_dbm, distinct_channels,
+    avg_data_rate_mbps (all signal fields are None when has_radiotap is False).
 
     Returns {"error": ..., "hint": ...} when no ethernet_frames rows exist.
     """
@@ -31,7 +33,25 @@ def get_layer2_summary() -> dict:
         "SELECT link_type, has_radiotap FROM capture_info LIMIT 1"
     ).fetchone()
     link_type = ci[0] if ci else None
-    has_radiotap = ci[1] if ci else False
+    has_radiotap = bool(ci[1]) if ci else False
+
+    if has_radiotap:
+        radio_row = conn.execute(
+            "SELECT AVG(signal_dbm), MIN(signal_dbm), MAX(signal_dbm),"
+            " AVG(data_rate_mbps) FROM radiotap_frames"
+        ).fetchone()
+        channel_rows = conn.execute(
+            "SELECT DISTINCT channel FROM radiotap_frames"
+            " WHERE channel IS NOT NULL ORDER BY channel"
+        ).fetchall()
+        avg_signal_dbm = radio_row[0]
+        min_signal_dbm = radio_row[1]
+        max_signal_dbm = radio_row[2]
+        avg_data_rate_mbps = radio_row[3]
+        distinct_channels = [r[0] for r in channel_rows]
+    else:
+        avg_signal_dbm = min_signal_dbm = max_signal_dbm = avg_data_rate_mbps = None
+        distinct_channels = []
 
     arp_counts = conn.execute(
         "SELECT operation, COUNT(*) FROM arp_packets GROUP BY operation"
@@ -74,6 +94,11 @@ def get_layer2_summary() -> dict:
         "distinct_vlan_ids": distinct_vlan_ids,
         "top_5_src_macs": [{"mac": r[0], "count": r[1]} for r in top_src],
         "top_5_dst_macs": [{"mac": r[0], "count": r[1]} for r in top_dst],
+        "avg_signal_dbm": avg_signal_dbm,
+        "min_signal_dbm": min_signal_dbm,
+        "max_signal_dbm": max_signal_dbm,
+        "distinct_channels": distinct_channels,
+        "avg_data_rate_mbps": avg_data_rate_mbps,
     }
     logger.debug("get_layer2_summary: %d ethernet frames", eth_count)
     return result

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -15,3 +15,21 @@ class TestCreateAgent:
     def test_system_prompt_no_file_context_when_not_provided(self):
         chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
         assert "already ingested" not in chat.system_prompt
+
+    def test_system_prompt_includes_schema_when_provided(self):
+        schema = "Database schema:\n  packets: frame_id BIGINT"
+        chat = create_agent(
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            pcap_file="/data/test.pcap",
+            schema=schema,
+        )
+        assert schema in chat.system_prompt
+
+    def test_system_prompt_no_schema_block_when_not_provided(self):
+        chat = create_agent(
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            pcap_file="/data/test.pcap",
+        )
+        assert "Database schema:" not in chat.system_prompt

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -218,3 +218,42 @@ class TestRadiotapFrames:
             ).fetchall()
         }
         assert cols == {"frame_id", "signal_dbm", "channel", "data_rate_mbps"}
+
+
+class TestGetSchema:
+    _ANALYSIS_TABLES = {
+        "packets",
+        "tcp_segments",
+        "udp_datagrams",
+        "icmp_messages",
+        "ethernet_frames",
+        "arp_packets",
+        "radiotap_frames",
+    }
+
+    def test_returns_string(self, duckdb_conn):
+        result = db.get_schema(duckdb_conn)
+        assert isinstance(result, str)
+
+    def test_starts_with_header(self, duckdb_conn):
+        result = db.get_schema(duckdb_conn)
+        assert result.startswith("Database schema:")
+
+    def test_analysis_tables_included(self, duckdb_conn):
+        result = db.get_schema(duckdb_conn)
+        for table in self._ANALYSIS_TABLES:
+            assert table in result
+
+    def test_capture_info_excluded(self, duckdb_conn):
+        result = db.get_schema(duckdb_conn)
+        assert "capture_info" not in result
+
+    def test_pcap_meta_excluded(self, duckdb_conn):
+        result = db.get_schema(duckdb_conn)
+        assert "pcap_meta" not in result
+
+    def test_radiotap_frames_columns_present(self, duckdb_conn):
+        result = db.get_schema(duckdb_conn)
+        assert "signal_dbm" in result
+        assert "channel" in result
+        assert "data_rate_mbps" in result

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -101,6 +101,11 @@ class TestIngestPcap:
         ).fetchone()[0]
         assert count == 0
 
+    def test_summary_has_schema_key(self, ingested_db):
+        assert "schema" in ingested_db
+        assert isinstance(ingested_db["schema"], str)
+        assert len(ingested_db["schema"]) > 0
+
 
 class TestIngestCaching:
     def test_second_ingest_returns_cached(
@@ -137,6 +142,16 @@ class TestIngestCaching:
         result2 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
         assert isinstance(result2["top_talkers"], list)
         assert len(result2["top_talkers"]) > 0
+
+    def test_cached_result_has_schema_key(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        result2 = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert "schema" in result2
+        assert isinstance(result2["schema"], str)
+        assert len(result2["schema"]) > 0
 
     @pytest.mark.parametrize(
         "missing_table",

--- a/tests/test_layer2_tool.py
+++ b/tests/test_layer2_tool.py
@@ -179,8 +179,94 @@ class TestGetLayer2SummaryEthernetCapture:
             "distinct_vlan_ids",
             "top_5_src_macs",
             "top_5_dst_macs",
+            "avg_signal_dbm",
+            "min_signal_dbm",
+            "max_signal_dbm",
+            "distinct_channels",
+            "avg_data_rate_mbps",
         }
         assert set(result.keys()) == expected_keys
+
+    def test_radio_stats_none_for_non_radiotap(self, eth_conn):
+        result = get_layer2_summary()
+        assert result["avg_signal_dbm"] is None
+        assert result["min_signal_dbm"] is None
+        assert result["max_signal_dbm"] is None
+        assert result["avg_data_rate_mbps"] is None
+        assert result["distinct_channels"] == []
+
+
+_RT_FRAMES = [
+    {"signal_dbm": -65.0, "channel": 6, "data_rate_mbps": 54.0},
+    {"signal_dbm": -72.0, "channel": 36, "data_rate_mbps": 12.0},
+    {"signal_dbm": -80.0, "channel": 6, "data_rate_mbps": 2.0},
+]
+_RT_AVG_SIGNAL = sum(f["signal_dbm"] for f in _RT_FRAMES) / len(_RT_FRAMES)
+_RT_MIN_SIGNAL = min(f["signal_dbm"] for f in _RT_FRAMES)
+_RT_MAX_SIGNAL = max(f["signal_dbm"] for f in _RT_FRAMES)
+_RT_DISTINCT_CHANNELS = sorted({f["channel"] for f in _RT_FRAMES})
+_RT_AVG_RATE = sum(f["data_rate_mbps"] for f in _RT_FRAMES) / len(_RT_FRAMES)
+
+
+@pytest.fixture()
+def radiotap_conn(eth_pcap):
+    """In-memory DB with one Ethernet frame plus radiotap_frames rows."""
+    from pcap_agent import parser
+
+    conn = duckdb.connect(":memory:")
+    db.create_schema(conn)
+    parsed = parser.parse(eth_pcap)
+    db.ingest(conn, parsed)
+    db.set_capture_info(
+        conn,
+        sha256="rt-test-sha256",
+        link_type=parsed.link_type,
+        has_radiotap=True,
+    )
+    for i, frame in enumerate(_RT_FRAMES):
+        conn.execute(
+            "INSERT INTO radiotap_frames"
+            " (frame_id, signal_dbm, channel, data_rate_mbps)"
+            " VALUES (?, ?, ?, ?)",
+            [1000 + i, frame["signal_dbm"], frame["channel"], frame["data_rate_mbps"]],
+        )
+    old = _state.get_connection()
+    old_path = _state.get_db_path()
+    _state.set_connection(conn, ":memory:")
+    yield conn
+    _state.set_connection(old, old_path) if old else _state.reset()
+    conn.close()
+
+
+class TestGetLayer2SummaryRadiotapCapture:
+    def test_has_radiotap_true(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["has_radiotap"] is True
+
+    def test_avg_signal_dbm(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["avg_signal_dbm"] == pytest.approx(_RT_AVG_SIGNAL)
+
+    def test_min_signal_dbm(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["min_signal_dbm"] == pytest.approx(_RT_MIN_SIGNAL)
+
+    def test_max_signal_dbm(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["max_signal_dbm"] == pytest.approx(_RT_MAX_SIGNAL)
+
+    def test_distinct_channels_from_per_frame_data(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["distinct_channels"] == _RT_DISTINCT_CHANNELS
+
+    def test_avg_data_rate_mbps(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["avg_data_rate_mbps"] == pytest.approx(_RT_AVG_RATE)
+
+    def test_signal_variation_across_frames(self, radiotap_conn):
+        result = get_layer2_summary()
+        assert result["min_signal_dbm"] < result["avg_signal_dbm"]
+        assert result["avg_signal_dbm"] < result["max_signal_dbm"]
 
 
 class TestGetLayer2SummaryNoEthernetData:


### PR DESCRIPTION
## Summary

Updates `get_layer2_summary()` to surface per-frame radio signal statistics from `radiotap_frames`, and adds a `get_schema()` function to `db.py` that emits the agent-facing DB schema while excluding internal tables (`capture_info`, `pcap_meta`). The schema is now injected into the agent's system prompt at startup and returned in the `ingest_pcap` result dict for mid-conversation captures.

## Acceptance Criteria

- [x] `get_layer2_summary()` queries `radiotap_frames` for radio signal stats (signal, channel, data rate)
- [x] `capture_info` is excluded from the agent schema injection
- [x] `radiotap_frames` is included in the agent schema injection
- [x] `test_layer2_tool.py` updated to verify radio stats come from per-frame data
- [x] Full test suite passes (`uv run pytest`)

## Changes

- `get_layer2_summary()` now queries `radiotap_frames` for `avg/min/max signal_dbm`, `distinct_channels`, and `avg_data_rate_mbps`; all five fields are present in every result (None/[] for non-radiotap captures)
- `db.get_schema()` returns a compact schema string excluding `capture_info` and `pcap_meta`
- `create_agent()` accepts an optional `schema=` parameter and appends it to the system prompt
- `ingest_pcap` result dict now includes a `"schema"` key (both fresh and cache-hit paths)
- `cli.py` passes the ingest schema to `create_agent()` for pre-loaded PCAPs

## Testing

- `TestGetLayer2SummaryRadiotapCapture`: verifies avg/min/max signal, distinct channels, and data rate against known per-frame fixture values
- `TestGetSchema`: verifies all analysis tables appear, `capture_info` and `pcap_meta` are excluded, and `radiotap_frames` columns are present
- `TestCreateAgent`: verifies schema appears in system prompt when provided, absent when not
- `TestIngestPcap` / `TestIngestCaching`: verifies `"schema"` key is present and non-empty on both fresh and cached ingest

## Related Issues

Closes #55