### PR TITLE
feat(ingest): add force-reingest via PCAP_AGENT_FORCE_REINGEST

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ pytest collects files alphabetically. Tests in `test_query_tool.py` run after `t
 | `PCAP_AGENT_UI` | `console` | UI mode |
 | `PCAP_AGENT_LOG_LEVEL` | `WARNING` | Root logger level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
 | `PCAP_AGENT_LOG_FILE` | `""` | Route log output to this file (append mode) instead of stderr |
+| `PCAP_AGENT_FORCE_REINGEST` | `""` | Set to `true` or `1` to clear cached data and force re-ingest |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | OpenTelemetry OTLP endpoint |
 
 Tests set `ANTHROPIC_API_KEY=test-dummy-key` via `pytest_configure` in `conftest.py`.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ All options can be set via CLI flags or environment variables. CLI flags take pr
 | `PCAP_AGENT_UI` | `console` | `--ui` | UI mode: `console` or `app` |
 | `PCAP_AGENT_LOG_LEVEL` | `WARNING` | `--log-level` | Log level: `DEBUG` `INFO` `WARNING` `ERROR` `CRITICAL` |
 | `PCAP_AGENT_LOG_FILE` | `""` | `--log-file` | Write logs to a file instead of stderr |
+| `PCAP_AGENT_FORCE_REINGEST` | `""` | — | Set to `true` or `1` to clear cached data and re-ingest |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` | `--otlp-endpoint` | OTLP endpoint (empty = telemetry off) |
 
 Set variables in `.envrc` (or `.env`) to avoid repeating them on every invocation.

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -21,10 +22,15 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     Returns cached results (cached=True) without re-parsing if the file was
     already ingested (same SHA256). Otherwise parses, persists, and auto-runs
     protocol breakdown and top-talker analysis.
+
+    When PCAP_AGENT_FORCE_REINGEST is set to "true" or "1" (case-insensitive),
+    any existing cached data is cleared and the file is re-ingested; the result
+    dict will have forced=True in that case.
     """
     pcap_path = Path(path)
     logger.info("Starting ingest for %s", pcap_path)
     sha256 = _sha256(pcap_path)
+    force_reingest = _is_force_reingest()
 
     effective_db_dir = db_dir or config.pcap_agent_db_dir
     Path(effective_db_dir).mkdir(parents=True, exist_ok=True)
@@ -51,8 +57,16 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
             old_conn.close()
 
     clear_stale = False
+    force_clear = False
     if db.get_cached(conn, sha256) is not None:
-        if schema_was_stale:
+        if force_reingest:
+            logger.warning(
+                "Force re-ingest active (sha256=%s path=%s), clearing cached data",
+                sha256,
+                pcap_path,
+            )
+            force_clear = True
+        elif schema_was_stale:
             logger.warning(
                 "Stale cache (sha256=%s path=%s): new tables missing, re-ingesting",
                 sha256,
@@ -65,12 +79,12 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
                 sha256,
                 pcap_path,
             )
-            return _summary(conn, sha256, db_path, cached=True)
+            return _summary(conn, sha256, db_path, cached=True, forced=False)
 
     frames = parser.parse(pcap_path)
     conn.begin()
     try:
-        if clear_stale:
+        if clear_stale or force_clear:
             db.clear_data(conn, sha256)
         db.ingest(conn, frames, begin_transaction=False)
         db.set_cached(conn, sha256, str(pcap_path))
@@ -85,7 +99,7 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
         conn.rollback()
         raise
 
-    return _summary(conn, sha256, db_path, cached=False)
+    return _summary(conn, sha256, db_path, cached=False, forced=force_clear)
 
 
 def _summary(
@@ -94,6 +108,7 @@ def _summary(
     db_path: str,
     *,
     cached: bool,
+    forced: bool,
 ) -> dict[str, Any]:
     n_packets = conn.execute("SELECT COUNT(*) FROM packets").fetchone()[0]
     if not cached:
@@ -105,6 +120,7 @@ def _summary(
     time_start, time_end = (row[0], row[1]) if row else (None, None)
     return {
         "cached": cached,
+        "forced": forced,
         "sha256": sha256,
         "n_packets": n_packets,
         "time_start": time_start,
@@ -114,6 +130,13 @@ def _summary(
         "db_path": db_path,
         "schema": db.get_schema(conn),
     }
+
+
+def _is_force_reingest() -> bool:
+    return os.environ.get("PCAP_AGENT_FORCE_REINGEST", "").strip().lower() in (
+        "true",
+        "1",
+    )
 
 
 def _sha256(path: Path) -> str:

--- a/src/pcap_agent/tools/ingest.py
+++ b/src/pcap_agent/tools/ingest.py
@@ -24,8 +24,9 @@ def ingest_pcap(path: str | Path, db_dir: str | None = None) -> dict[str, Any]:
     protocol breakdown and top-talker analysis.
 
     When PCAP_AGENT_FORCE_REINGEST is set to "true" or "1" (case-insensitive),
-    any existing cached data is cleared and the file is re-ingested; the result
-    dict will have forced=True in that case.
+    any existing cached data is cleared and the file is re-ingested. The result
+    dict includes forced=True only when a cached entry was actually found and
+    cleared; a first-time ingest with the env var set returns forced=False.
     """
     pcap_path = Path(path)
     logger.info("Starting ingest for %s", pcap_path)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -224,6 +224,20 @@ class TestIngestForceReingest:
         result = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
         assert result["forced"] is False
 
+    def test_force_reingest_on_first_ingest_returns_forced_false(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        import os
+
+        db_dir = str(tmp_path)
+        os.environ["PCAP_AGENT_FORCE_REINGEST"] = "true"
+        try:
+            result = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        finally:
+            os.environ.pop("PCAP_AGENT_FORCE_REINGEST", None)
+        assert result["cached"] is False
+        assert result["forced"] is False
+
     def test_force_reingest_env_unset_after_test(
         self, synthetic_pcap, tmp_path, _restore_state
     ):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -178,6 +178,67 @@ class TestIngestCaching:
         assert result2["n_packets"] == TOTAL_IP
 
 
+class TestIngestForceReingest:
+    def test_force_reingest_bypasses_cache(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        import os
+
+        os.environ["PCAP_AGENT_FORCE_REINGEST"] = "true"
+        try:
+            result = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        finally:
+            os.environ.pop("PCAP_AGENT_FORCE_REINGEST", None)
+        assert result["cached"] is False
+        assert result["forced"] is True
+        assert result["n_packets"] == TOTAL_IP
+
+    @pytest.mark.parametrize("env_val", ["true", "True", "TRUE", "1"])
+    def test_force_reingest_env_values(
+        self, synthetic_pcap, tmp_path, _restore_state, env_val
+    ):
+        import os
+
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        os.environ["PCAP_AGENT_FORCE_REINGEST"] = env_val
+        try:
+            result = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        finally:
+            os.environ.pop("PCAP_AGENT_FORCE_REINGEST", None)
+        assert result["forced"] is True
+
+    def test_no_force_reingest_returns_cached(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        result = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert result["cached"] is True
+        assert result["forced"] is False
+
+    def test_fresh_ingest_forced_false(self, synthetic_pcap, tmp_path, _restore_state):
+        db_dir = str(tmp_path)
+        result = ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        assert result["forced"] is False
+
+    def test_force_reingest_env_unset_after_test(
+        self, synthetic_pcap, tmp_path, _restore_state
+    ):
+        import os
+
+        db_dir = str(tmp_path)
+        ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        os.environ["PCAP_AGENT_FORCE_REINGEST"] = "1"
+        try:
+            ingest_pcap(str(synthetic_pcap), db_dir=db_dir)
+        finally:
+            os.environ.pop("PCAP_AGENT_FORCE_REINGEST", None)
+        assert "PCAP_AGENT_FORCE_REINGEST" not in os.environ
+
+
 class TestIngestRadiotap:
     @pytest.fixture()
     def radiotap_pcap(self, tmp_path):


### PR DESCRIPTION
## Summary

Adds `PCAP_AGENT_FORCE_REINGEST` env var support to `ingest_pcap`. When set
to `"true"` or `"1"` (case-insensitive), any cached data for the file is
cleared and the file is re-ingested from scratch, bypassing the SHA256 cache
check. The result dict gains a `forced` key that is `True` only when a cached
entry was actually found and cleared.

Closes #60

## Changes

- `ingest_pcap` reads `PCAP_AGENT_FORCE_REINGEST` from `os.environ` at call
  time (per ADR-0001, not from the config singleton)
- Calls `clear_data(conn, sha256)` before re-parsing when force re-ingest is
  active and a cached entry exists
- Result dict includes `forced=True` when a forced re-ingest ran,
  `forced=False` otherwise (including on a first-time ingest with the env var
  set)
- Default behavior unchanged: cache hit still returns early with `cached=True`
  when the env var is unset
- Env var documented in `CLAUDE.md` and `README.md`

## Testing

Integration tests in `TestIngestForceReingest` cover:

- Force re-ingest bypasses cache (`cached=False`, `forced=True`, correct packet count)
- All truthy env values: `true`, `True`, `TRUE`, `1`
- Default (no env var) still returns cached result (`forced=False`)
- First-time ingest with env var set returns `forced=False` (no cache was cleared)
- Env var is cleaned up in teardown so it does not leak to other tests

Run with: `uv run pytest tests/test_ingest.py -v`

## Related Issues

Closes #60
