### PR TITLE
feat(cli): add --force-reingest flag and update synopsis

### DIFF
--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -9,7 +9,12 @@ import click
 
 
 def _print_synopsis(pcap_file: str, result: dict[str, Any]) -> None:
-    label = "(from cache)" if result.get("cached") else "(new)"
+    if result.get("forced"):
+        label = "(forced re-ingest)"
+    elif result.get("cached"):
+        label = "(from cache)"
+    else:
+        label = "(new)"
     click.echo(
         f"\nLoaded {Path(pcap_file).name} {label} — {result['n_packets']} packets"
     )
@@ -80,6 +85,13 @@ def _print_synopsis(pcap_file: str, result: dict[str, Any]) -> None:
     help="Route log output to this file (append mode) instead of stderr"
     " [env: PCAP_AGENT_LOG_FILE]",
 )
+@click.option(
+    "--force-reingest",
+    envvar="PCAP_AGENT_FORCE_REINGEST",
+    is_flag=True,
+    default=False,
+    help="Clear cached data and force re-ingest [env: PCAP_AGENT_FORCE_REINGEST]",
+)
 def main(
     pcap_file: str | None,
     api_key: str,
@@ -89,6 +101,7 @@ def main(
     otlp_endpoint: str,
     log_level: str,
     log_file: str,
+    force_reingest: bool,
 ) -> None:
     """PCAP analysis agent powered by Claude.
 
@@ -113,6 +126,8 @@ def main(
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint
     os.environ["PCAP_AGENT_LOG_LEVEL"] = log_level
     os.environ["PCAP_AGENT_LOG_FILE"] = log_file
+    if force_reingest:
+        os.environ["PCAP_AGENT_FORCE_REINGEST"] = "true"
 
     from pcap_agent import telemetry
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the CLI entry point."""
 
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import duckdb
@@ -165,3 +166,51 @@ class TestCliLogFile:
         )
         assert result.exit_code != 0
         assert "Error" in result.output or "Error" in (result.output or "")
+
+
+class TestCliForceReingest:
+    """CLI --force-reingest flag sets the env var and updates the synopsis."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self):
+        saved = {
+            k: os.environ.pop(k, None)
+            for k in ("PCAP_AGENT_FORCE_REINGEST", "PCAP_AGENT_LOG_FILE")
+        }
+        yield
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def _invoke(self, cli_runner, mock_chat, pcap_path, db_dir, extra_args=None):
+        args = [
+            str(pcap_path),
+            "--api-key", "test-key",
+            "--db-dir", str(db_dir),
+            "--ui", "console",
+        ]
+        if extra_args:
+            args += extra_args
+        with patch("pcap_agent.agent.create_agent", return_value=mock_chat):
+            return cli_runner.invoke(main, args, catch_exceptions=False)
+
+    def test_force_reingest_synopsis_shows_forced_label(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        self._invoke(cli_runner, mock_chat, synthetic_pcap, tmp_path)
+        result = self._invoke(
+            cli_runner, mock_chat, synthetic_pcap, tmp_path,
+            extra_args=["--force-reingest"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "(forced re-ingest)" in result.output
+
+    def test_no_force_reingest_flag_does_not_set_env_var(
+        self, cli_runner, mock_chat, synthetic_pcap, tmp_path
+    ):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PCAP_AGENT_FORCE_REINGEST", None)
+            self._invoke(cli_runner, mock_chat, synthetic_pcap, tmp_path)
+            assert os.environ.get("PCAP_AGENT_FORCE_REINGEST") is None


### PR DESCRIPTION
## Summary

Exposes the force-reingest feature at the CLI layer via a `--force-reingest` boolean flag backed by the `PCAP_AGENT_FORCE_REINGEST` env var. The flag sets `os.environ` before any config-dependent imports, following the existing pattern in `cli.py`. The ingest synopsis now shows `(forced re-ingest)` when a cached entry was cleared and re-ingested.

Closes #61

## Changes

- Add `--force-reingest` flag to `main()` with `envvar="PCAP_AGENT_FORCE_REINGEST"`
- Set `os.environ["PCAP_AGENT_FORCE_REINGEST"] = "true"` before lazy imports when the flag is present
- Update `_print_synopsis` to show `"(forced re-ingest)"` when `result.get("forced")` is true
- Add `TestCliForceReingest` with two CliRunner tests: synopsis label and env var isolation

## Testing

Full test suite passes (`uv run pytest`, 270 tests). New tests in `TestCliForceReingest`:
- `test_force_reingest_synopsis_shows_forced_label`: ingests once, then re-invokes with `--force-reingest` and asserts `(forced re-ingest)` appears in output
- `test_no_force_reingest_flag_does_not_set_env_var`: verifies `PCAP_AGENT_FORCE_REINGEST` is absent from the environment when the flag is not passed

## Related Issues

Closes #61