### PR TITLE
feat(tools): add ZIP support to decode_payload

### DIFF
--- a/src/pcap_agent/tools/decode_payload.py
+++ b/src/pcap_agent/tools/decode_payload.py
@@ -45,7 +45,8 @@ def decode_payload(
         if raw[:4] == _ZIP_MAGIC:
             return _handle_zip(raw, member=member if isinstance(member, str) else None)
         if raw[:2] == _GZIP_MAGIC:
-            return _decompress_gzip(raw, member=member or 0)
+            gzip_member = member if isinstance(member, int) else 0
+            return _decompress_gzip(raw, member=gzip_member)
         if raw[:2] in _ZLIB_MAGICS:
             return _decompress_zlib(raw)
         return {
@@ -91,6 +92,13 @@ def _handle_zip(raw: bytes, member: str | None = None) -> dict:
         }
 
     data = zf.read(member)
+    if len(data) > _MAX_BYTES:
+        sz = len(data)
+        msg = f"Member {member!r} decompressed to {sz} bytes, exceeding {_MAX_BYTES}."
+        return {
+            "error": msg,
+            "hint": "Extract a smaller member or use a different tool.",
+        }
     return _encode_output(data)
 
 

--- a/src/pcap_agent/tools/decode_payload.py
+++ b/src/pcap_agent/tools/decode_payload.py
@@ -2,30 +2,33 @@
 
 from __future__ import annotations
 
+import io
+import zipfile
 import zlib
 
 _MAX_BYTES = 64 * 1024
 
 _GZIP_MAGIC = b"\x1f\x8b"
 _ZLIB_MAGICS = {b"\x78\x9c", b"\x78\x01", b"\x78\xda"}
+_ZIP_MAGIC = b"\x50\x4b\x03\x04"
 
 
 def decode_payload(
     data: str,
     format: str = "auto",  # noqa: A002
-    member: int | None = None,
+    member: int | str | None = None,
 ) -> dict:
-    """Decompress a hex-encoded payload string.
+    """Decompress or decode a hex-encoded payload string.
 
     Parameters
     ----------
     data:
         Hex-encoded bytes (e.g. output of DuckDB ``hex()`` or ``reassemble_stream``).
     format:
-        ``'auto'`` detects gzip/zlib via magic bytes. ``'deflate'`` forces raw DEFLATE.
+        ``'auto'`` detects gzip/zlib/zip via magic bytes; ``'deflate'`` forces DEFLATE.
     member:
-        For multi-member gzip streams, select the 0-based member index to return.
-        Defaults to 0 (first member).
+        ZIP: a filename string to extract that member (omit to list all members).
+        gzip: a 0-based integer index to select a multi-member stream member.
     """
     try:
         raw = bytes.fromhex(data)
@@ -39,6 +42,8 @@ def decode_payload(
         return _decompress_deflate(raw)
 
     if format == "auto":
+        if raw[:4] == _ZIP_MAGIC:
+            return _handle_zip(raw, member=member if isinstance(member, str) else None)
         if raw[:2] == _GZIP_MAGIC:
             return _decompress_gzip(raw, member=member or 0)
         if raw[:2] in _ZLIB_MAGICS:
@@ -49,6 +54,44 @@ def decode_payload(
         }
 
     return {"error": f"Unknown format: {format!r}", "hint": "Use 'auto', 'deflate'."}
+
+
+def _handle_zip(raw: bytes, member: str | None = None) -> dict:
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(raw))
+    except zipfile.BadZipFile as exc:
+        return {
+            "error": f"ZIP parse failed: {exc}",
+            "hint": "Verify the payload is a valid ZIP archive.",
+        }
+
+    if member is None:
+        return {
+            "members": [
+                {
+                    "name": info.filename,
+                    "size": info.file_size,
+                    "compressed_size": info.compress_size,
+                }
+                for info in zf.infolist()
+            ]
+        }
+
+    info_map = {info.filename: info for info in zf.infolist()}
+    if member not in info_map:
+        return {"error": f"Member {member!r} not found.", "hint": "list members first"}
+
+    info = info_map[member]
+    if info.file_size > _MAX_BYTES:
+        sz = info.file_size
+        msg = f"Member {member!r} is {sz} bytes, exceeding the {_MAX_BYTES}-byte limit."
+        return {
+            "error": msg,
+            "hint": "Extract a smaller member or use a different tool.",
+        }
+
+    data = zf.read(member)
+    return _encode_output(data)
 
 
 def _decompress_gzip(raw: bytes, member: int = 0) -> dict:

--- a/tests/test_decode_payload_tool.py
+++ b/tests/test_decode_payload_tool.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import gzip
+import io
+import zipfile
 import zlib
 
 from pcap_agent.tools.decode_payload import decode_payload
@@ -185,3 +187,63 @@ class TestMemberSelection:
 
         assert "error" not in result
         assert result["content"] == "second member data"
+
+
+def _make_zip(*members: tuple[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members:
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+class TestZipMemberListing:
+    def test_zip_magic_bytes_trigger_member_listing(self):
+        zip_bytes = _make_zip(("hello.txt", b"Hello"), ("world.txt", b"World"))
+        result = decode_payload(zip_bytes.hex())
+
+        assert "error" not in result
+        assert "members" in result
+        members = result["members"]
+        assert len(members) == 2
+        names = {m["name"] for m in members}
+        assert names == {"hello.txt", "world.txt"}
+        for m in members:
+            assert "size" in m
+            assert "compressed_size" in m
+
+
+class TestZipMemberExtraction:
+    def test_extract_text_member_by_name(self):
+        zip_bytes = _make_zip(("readme.txt", b"Hello from ZIP"))
+        result = decode_payload(zip_bytes.hex(), member="readme.txt")
+
+        assert "error" not in result
+        assert result["content"] == "Hello from ZIP"
+        assert result["content_encoding"] == "utf-8"
+
+    def test_extract_binary_member_returns_hex(self):
+        binary_data = bytes(range(256))
+        zip_bytes = _make_zip(("data.bin", binary_data))
+        result = decode_payload(zip_bytes.hex(), member="data.bin")
+
+        assert "error" not in result
+        assert result["content_encoding"] == "hex"
+        assert result["content"] == binary_data.hex()
+
+    def test_member_exceeding_64kb_returns_hard_error(self):
+        large_data = b"X" * (_MAX_BYTES + 1)
+        zip_bytes = _make_zip(("big.txt", large_data))
+        result = decode_payload(zip_bytes.hex(), member="big.txt")
+
+        assert "error" in result
+        assert "truncated" not in result
+
+
+class TestZipMemberNotFound:
+    def test_nonexistent_member_returns_structured_error(self):
+        zip_bytes = _make_zip(("exists.txt", b"data"))
+        result = decode_payload(zip_bytes.hex(), member="does_not_exist.txt")
+
+        assert "error" in result
+        assert result.get("hint") == "list members first"


### PR DESCRIPTION
## Summary

Extends `decode_payload` to handle ZIP archives (including ZIP-based
containers like docx, xlsx, pptx). Magic-byte auto-detection (`PK\x03\x04`)
triggers ZIP mode automatically — no format flag needed. All decompression
is in-memory; nothing is written to disk.

## Changes

- Auto-detect ZIP via `PK\x03\x04` magic bytes in `format='auto'` path
- Member listing: returns list of dicts with `name`, `size` (uncompressed),
  and `compressed_size`; triggered when no `member` argument is given
- Member extraction: `member=<filename>` extracts content as UTF-8 text or
  hex-encoded bytes if binary
- Hard error (not truncation) when a member exceeds 64 KB, guarded by both
  ZIP metadata and post-decompression `len(data)` check to catch spoofed
  `file_size` values in crafted archives
- Structured `{"error": ..., "hint": "list members first"}` when a requested
  member does not exist
- `member` type widened to `int | str | None`; gzip path now uses an
  `isinstance` guard to prevent `TypeError` when a string is passed

## Testing

All behaviors covered by unit tests in `tests/test_decode_payload_tool.py`:

- `TestZipMemberListing` — magic byte detection, listing with name/size/compressed_size
- `TestZipMemberExtraction` — UTF-8 extraction, binary hex fallback, oversized member hard error
- `TestZipMemberNotFound` — structured error with hint

Full suite: `uv run pytest` (293 tests pass).

## Related Issues

Closes #65
