### PR TITLE
feat(agent): register decode_payload as 8th tool with system prompt hint

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -26,6 +26,8 @@ call ingest_pcap before answering.
 - Render any tabular data as a markdown table.
 - After each answer, suggest one or two follow-up angles the analyst should consider.
 - Do not explain what the tools do unless asked.
+- When a payload is returned as hex-encoded bytes, call decode_payload \
+to decompress or unpack it before presenting results to the user.
 
 Capability boundary:
 

--- a/src/pcap_agent/tools/decode_payload.py
+++ b/src/pcap_agent/tools/decode_payload.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import io
+import logging
 import zipfile
 import zlib
+
+logger = logging.getLogger(__name__)
 
 _MAX_BYTES = 64 * 1024
 
@@ -37,6 +40,8 @@ def decode_payload(
             "error": f"Invalid hex input: {exc}",
             "hint": "Provide a valid hex string.",
         }
+
+    logger.debug("decode_payload: format=%s, input=%d bytes", format, len(raw))
 
     if format == "deflate":
         return _decompress_deflate(raw)
@@ -164,6 +169,7 @@ def _encode_output(data: bytes) -> dict:
     if len(data) > _MAX_BYTES:
         data = data[:_MAX_BYTES]
         truncated = True
+        logger.warning("decode_payload: output truncated at %d bytes", _MAX_BYTES)
 
     try:
         content = data.decode("utf-8")
@@ -172,6 +178,7 @@ def _encode_output(data: bytes) -> dict:
         content = data.hex()
         content_encoding = "hex"
 
+    logger.info("decode_payload: decoded %d bytes as %s", len(data), content_encoding)
     return {
         "content": content,
         "content_encoding": content_encoding,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -33,3 +33,16 @@ class TestCreateAgent:
             pcap_file="/data/test.pcap",
         )
         assert "Database schema:" not in chat.system_prompt
+
+    def test_system_prompt_contains_decode_payload_hint(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        assert (
+            "When a payload is returned as hex-encoded bytes, call decode_payload"
+            " to decompress or unpack it before presenting results to the user."
+            in chat.system_prompt
+        )
+
+    def test_decode_payload_registered_as_tool(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        tool_names = [t.name for t in chat.get_tools()]
+        assert "decode_payload" in tool_names


### PR DESCRIPTION
## Summary

Completes the integration of `decode_payload` as a first-class agent tool by
adding a system prompt hint that instructs the agent to call it automatically
when it encounters hex-encoded payloads. Also adds structured logging to the
tool matching the pattern used by all other tools.

Closes #66

## Changes

- Add system prompt guideline: "When a payload is returned as hex-encoded
  bytes, call decode_payload to decompress or unpack it before presenting
  results to the user."
- Add `debug`, `info`, and `warning` log messages to `decode_payload`
  (entry with format/size, success with byte count and encoding, truncation
  warning at the 64 KB cap)
- Add tests asserting `decode_payload` appears in registered tool names
- Add test asserting the system prompt contains the decode hint string

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | `decode_payload` imported and registered in `agent.py` | Yes | `agent.py:9,75` (prior commits) |
| 2 | Tool wrapped with `instrument_tool()` | Yes | `agent.py:78` |
| 3 | System prompt includes the decode hint line | Yes | `agent.py:29-30`, `test_agent.py::test_system_prompt_contains_decode_payload_hint` |
| 4 | `uv run ruff check` passes | Yes | verified |
| 5 | Tests assert `decode_payload` in registered tool names | Yes | `test_agent.py::test_decode_payload_registered_as_tool` |
| 6 | Tests assert system prompt contains the decode hint string | Yes | `test_agent.py::test_system_prompt_contains_decode_payload_hint` |

## Testing

```bash
uv run pytest tests/test_agent.py -v
uv run pytest
```

295 tests pass.
