### PR TITLE
fix(tools): use MAX_BY to prefer push over ACK at same seq (#70)

### DIFF
--- a/src/pcap_agent/tools/reassembly.py
+++ b/src/pcap_agent/tools/reassembly.py
@@ -41,7 +41,7 @@ def reassemble_stream(
     if proto == "TCP":
         rows = conn.execute(
             """
-            SELECT FIRST(t.payload) AS payload
+            SELECT MAX_BY(t.payload, OCTET_LENGTH(t.payload)) AS payload
             FROM tcp_segments t
             JOIN packets p ON p.frame_id = t.frame_id
             WHERE p.src_ip = ?

--- a/tests/test_reassembly_tool.py
+++ b/tests/test_reassembly_tool.py
@@ -203,3 +203,40 @@ class TestTCPRetransmission:
 
         assert "error" not in result
         assert result["payload"] == "hello"
+
+
+class TestACKAndPushShareSeq:
+    """When ACK and push packets share a seq, the push payload must be returned."""
+
+    @pytest.fixture()
+    def ack_push_conn(self, duckdb_conn):
+        push_payload = b"OFT2data"
+        duckdb_conn.execute(
+            "INSERT INTO packets VALUES "
+            "(1, 1700000000.0, '1.1.1.1', '2.2.2.2', 6, 40, 64)"
+        )
+        duckdb_conn.execute(
+            "INSERT INTO packets VALUES "
+            "(2, 1700000001.0, '1.1.1.1', '2.2.2.2', 6, 48, 64)"
+        )
+        # ACK with no payload shares seq=1000
+        duckdb_conn.execute(
+            "INSERT INTO tcp_segments VALUES (1, 5000, 80, 'A', 1000, 0, NULL)"
+        )
+        # Push with real payload also at seq=1000
+        duckdb_conn.execute(
+            "INSERT INTO tcp_segments VALUES (2, 5000, 80, 'PA', 1000, 0, ?)",
+            [push_payload],
+        )
+        old = _state.get_connection()
+        old_path = _state.get_db_path()
+        _state.set_connection(duckdb_conn, ":memory:")
+        yield duckdb_conn, push_payload
+        _state.set_connection(old, old_path) if old else _state.reset()
+
+    def test_push_payload_wins_over_ack_at_same_seq(self, ack_push_conn):
+        _, push_payload = ack_push_conn
+        result = reassemble_stream("1.1.1.1", "2.2.2.2", 5000, 80, "TCP")
+
+        assert "error" not in result
+        assert result["payload"] == push_payload.decode("utf-8")


### PR DESCRIPTION
## Summary

`FIRST(t.payload)` picked non-deterministically when multiple TCP segments share a sequence number. An ACK packet with a null payload could win over a PSH packet carrying real data. Switch to `MAX_BY(t.payload, OCTET_LENGTH(t.payload))` so the segment with the most bytes wins.

Closes #70

## Changes

- Replace `FIRST(t.payload)` with `MAX_BY(t.payload, OCTET_LENGTH(t.payload))` in the TCP reassembly query in `reassembly.py`
- Add `TestACKAndPushShareSeq` with fixture and test in `test_reassembly_tool.py` asserting that a PSH payload wins over a co-seq ACK with a null payload

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | PSH payload wins over ACK with null payload at same seq | Yes | `test_reassembly_tool.py::TestACKAndPushShareSeq::test_push_payload_wins_over_ack_at_same_seq` |

## Testing

- `uv run ruff check` — clean
- `uv run pytest` — all tests pass