### PR TITLE
fix(cli,agent): recover from BadRequestError caused by malformed tool inputs

### DIFF
--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from chatlas import ChatAnthropic
+from chatlas import ChatAnthropic, ToolRejectError
 
 from pcap_agent import telemetry
 from pcap_agent.tools.analysis import get_protocol_breakdown, get_top_talkers
@@ -65,6 +65,14 @@ def create_agent(
         api_key=api_key,
     )
     logger.info("Agent session started (model=%s)", model)
+
+    def _reject_non_dict_input(request):
+        if not isinstance(request.arguments, dict):
+            raise ToolRejectError(
+                "Tool input must be an object, not a primitive value."
+            )
+
+    chat.on_tool_request(_reject_non_dict_input)
     _tools = [
         ingest_pcap,
         get_protocol_breakdown,

--- a/src/pcap_agent/agent.py
+++ b/src/pcap_agent/agent.py
@@ -49,6 +49,15 @@ Not supported (no data captured or decoded):
 _PCAP_LOADED_SUFFIX = "\nA PCAP file has already been ingested: `{pcap_file}`. \
 The data is ready for analysis."
 
+
+def reject_non_dict_tool_input(request) -> None:
+    """Raise ToolRejectError when the model emits a non-object tool argument."""
+    if not isinstance(request.arguments, dict):
+        raise ToolRejectError(
+            "Tool input must be an object, not a primitive value."
+        )
+
+
 def create_agent(
     *, api_key: str, model: str, pcap_file: str | None = None, schema: str | None = None
 ) -> "ChatAnthropic":
@@ -66,13 +75,7 @@ def create_agent(
     )
     logger.info("Agent session started (model=%s)", model)
 
-    def _reject_non_dict_input(request):
-        if not isinstance(request.arguments, dict):
-            raise ToolRejectError(
-                "Tool input must be an object, not a primitive value."
-            )
-
-    chat.on_tool_request(_reject_non_dict_input)
+    chat.on_tool_request(reject_non_dict_tool_input)
     _tools = [
         ingest_pcap,
         get_protocol_breakdown,

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -171,7 +171,9 @@ def main(
             try:
                 chat.console()
                 break
-            except anthropic.BadRequestError:
+            except anthropic.BadRequestError as exc:
+                if "tool_use.input" not in str(exc):
+                    raise
                 chat.set_turns(chat.get_turns()[:-1])
                 click.echo(
                     "[error] The model produced an invalid tool call and the turn"

--- a/src/pcap_agent/cli.py
+++ b/src/pcap_agent/cli.py
@@ -165,4 +165,15 @@ def main(
     if ui == "app":
         chat.app()
     else:
-        chat.console()
+        import anthropic
+
+        while True:
+            try:
+                chat.console()
+                break
+            except anthropic.BadRequestError:
+                chat.set_turns(chat.get_turns()[:-1])
+                click.echo(
+                    "[error] The model produced an invalid tool call and the turn"
+                    " was dropped. You can continue the conversation."
+                )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,10 +1,11 @@
 """Tests for agent creation and system prompt construction."""
 
+import types
+
 import pytest
 from chatlas import ToolRejectError
-from chatlas._content import ContentToolRequest
 
-from pcap_agent.agent import create_agent
+from pcap_agent.agent import create_agent, reject_non_dict_tool_input
 
 
 class TestCreateAgent:
@@ -52,22 +53,24 @@ class TestCreateAgent:
         assert "decode_payload" in tool_names
 
 
-class TestOnToolRequestCallback:
-    def test_raises_tool_reject_error_for_null_arguments(self):
-        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
-        request = ContentToolRequest(id="req-1", name="query", arguments=None)
-        with pytest.raises(ToolRejectError):
-            chat._on_tool_request_callbacks.invoke(request)
+class TestRejectNonDictToolInput:
+    def _req(self, arguments):
+        return types.SimpleNamespace(arguments=arguments)
 
-    def test_raises_tool_reject_error_for_string_arguments(self):
-        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
-        request = ContentToolRequest(id="req-2", name="query", arguments="bad input")
+    def test_raises_for_null_arguments(self):
         with pytest.raises(ToolRejectError):
-            chat._on_tool_request_callbacks.invoke(request)
+            reject_non_dict_tool_input(self._req(None))
+
+    def test_raises_for_string_arguments(self):
+        with pytest.raises(ToolRejectError):
+            reject_non_dict_tool_input(self._req("bad input"))
+
+    def test_raises_for_list_arguments(self):
+        with pytest.raises(ToolRejectError):
+            reject_non_dict_tool_input(self._req([1, 2, 3]))
 
     def test_does_not_raise_for_dict_arguments(self):
-        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
-        request = ContentToolRequest(
-            id="req-3", name="query", arguments={"sql": "SELECT 1"}
-        )
-        chat._on_tool_request_callbacks.invoke(request)
+        reject_non_dict_tool_input(self._req({"sql": "SELECT 1"}))
+
+    def test_does_not_raise_for_empty_dict(self):
+        reject_non_dict_tool_input(self._req({}))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -53,6 +53,14 @@ class TestCreateAgent:
         assert "decode_payload" in tool_names
 
 
+class TestCreateAgentToolRequestGuard:
+    def test_on_tool_request_guard_is_registered(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        req = types.SimpleNamespace(arguments=None)
+        with pytest.raises(ToolRejectError):
+            chat._on_tool_request_callbacks.invoke(req)
+
+
 class TestRejectNonDictToolInput:
     def _req(self, arguments):
         return types.SimpleNamespace(arguments=arguments)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,9 @@
 """Tests for agent creation and system prompt construction."""
 
+import pytest
+from chatlas import ToolRejectError
+from chatlas._content import ContentToolRequest
+
 from pcap_agent.agent import create_agent
 
 
@@ -46,3 +50,24 @@ class TestCreateAgent:
         chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
         tool_names = [t.name for t in chat.get_tools()]
         assert "decode_payload" in tool_names
+
+
+class TestOnToolRequestCallback:
+    def test_raises_tool_reject_error_for_null_arguments(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        request = ContentToolRequest(id="req-1", name="query", arguments=None)
+        with pytest.raises(ToolRejectError):
+            chat._on_tool_request_callbacks.invoke(request)
+
+    def test_raises_tool_reject_error_for_string_arguments(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        request = ContentToolRequest(id="req-2", name="query", arguments="bad input")
+        with pytest.raises(ToolRejectError):
+            chat._on_tool_request_callbacks.invoke(request)
+
+    def test_does_not_raise_for_dict_arguments(self):
+        chat = create_agent(api_key="test-key", model="claude-sonnet-4-6")
+        request = ContentToolRequest(
+            id="req-3", name="query", arguments={"sql": "SELECT 1"}
+        )
+        chat._on_tool_request_callbacks.invoke(request)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,22 @@ class TestCliBadRequestRecovery:
         assert "invalid tool call" in result.output.lower()
         assert "continue" in result.output.lower()
 
+    def test_unrelated_bad_request_error_is_reraised(self, cli_runner):
+        mock_chat = MagicMock()
+        mock_chat.get_turns.return_value = [MagicMock()]
+        mock_chat.console.side_effect = _make_bad_request_error(
+            "Your credit balance is too low"
+        )
+
+        with patch("pcap_agent.agent.create_agent", return_value=mock_chat):
+            result = cli_runner.invoke(
+                main,
+                ["--api-key", "test-key"],
+            )
+
+        assert result.exit_code != 0
+        mock_chat.set_turns.assert_not_called()
+
 
 class TestCliForceReingest:
     """CLI --force-reingest flag sets the env var and updates the synopsis."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,9 @@ import logging
 import os
 from unittest.mock import MagicMock, patch
 
+import anthropic
 import duckdb
+import httpx
 import pytest
 from click.testing import CliRunner
 from constants import TOTAL_FRAMES, UDP_TOP_TALKER_IP
@@ -166,6 +168,61 @@ class TestCliLogFile:
         )
         assert result.exit_code != 0
         assert "Error" in result.output or "Error" in (result.output or "")
+
+
+def _make_bad_request_error(
+    msg: str = "messages.0.content.0.tool_use.input: Input should be an object",
+) -> anthropic.BadRequestError:
+    response = httpx.Response(
+        400, request=httpx.Request("POST", "https://api.anthropic.com")
+    )
+    return anthropic.BadRequestError(msg, response=response, body=None)
+
+
+class TestCliBadRequestRecovery:
+    """CLI recovers from BadRequestError by popping the malformed turn."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self):
+        saved = {k: os.environ.pop(k, None) for k in ("PCAP_AGENT_LOG_FILE",)}
+        yield
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def test_bad_request_error_pops_last_turn_and_continues(self, cli_runner):
+        turns = [MagicMock(), MagicMock()]
+        mock_chat = MagicMock()
+        mock_chat.get_turns.return_value = turns
+        mock_chat.console.side_effect = [_make_bad_request_error(), None]
+
+        with patch("pcap_agent.agent.create_agent", return_value=mock_chat):
+            result = cli_runner.invoke(
+                main,
+                ["--api-key", "test-key"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        mock_chat.set_turns.assert_called_once_with(turns[:-1])
+        assert "[error]" in result.output
+
+    def test_bad_request_error_prints_recoverable_message(self, cli_runner):
+        mock_chat = MagicMock()
+        mock_chat.get_turns.return_value = [MagicMock()]
+        mock_chat.console.side_effect = [_make_bad_request_error(), None]
+
+        with patch("pcap_agent.agent.create_agent", return_value=mock_chat):
+            result = cli_runner.invoke(
+                main,
+                ["--api-key", "test-key"],
+                catch_exceptions=False,
+            )
+
+        assert "invalid tool call" in result.output.lower()
+        assert "continue" in result.output.lower()
 
 
 class TestCliForceReingest:


### PR DESCRIPTION
## Summary

Two-layer defence against the session crash that occurs when the model emits a `tool_use` with a non-object input (e.g. `null`).

- **Layer 1 (agent.py):** An `on_tool_request` callback rejects any tool call whose `arguments` is not a `dict` by raising `ToolRejectError`, giving the model a structured error result and a chance to self-correct.
- **Layer 2 (cli.py):** The `chat.console()` REPL loop is wrapped in a `try/except anthropic.BadRequestError` that only catches errors containing `"tool_use.input"` in the message. On match, the malformed assistant turn is popped via `set_turns()` and the user sees a brief recoverable message; unrelated 400 errors (credit limit, content policy, etc.) are re-raised.

Closes #71

## Changes

- `agent.py`: Add `reject_non_dict_tool_input` module-level function and register it via `chat.on_tool_request()`
- `cli.py`: Wrap `chat.console()` in a `while True` / `try/except BadRequestError` recovery loop, narrowed to `"tool_use.input"` errors
- `tests/test_agent.py`: Unit tests for `reject_non_dict_tool_input` (null, string, list, dict, empty dict) plus one integration test confirming the guard is wired into the chat object
- `tests/test_cli.py`: Tests for turn-pop behaviour, recoverable message output, and re-raise of unrelated 400 errors

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | `on_tool_request` callback registered in `agent.py` that raises `ToolRejectError` for non-dict input | Yes | `agent.py`: `reject_non_dict_tool_input` + `chat.on_tool_request()` |
| 2 | Test verifies callback returns structured error for non-dict argument | Yes | `test_agent.py::TestCreateAgentToolRequestGuard`, `TestRejectNonDictToolInput` |
| 3 | `cli.py` catches `BadRequestError`, pops last turn, prints recoverable message | Yes | `cli.py`: while loop + `set_turns` + `click.echo`; `test_cli.py::TestCliBadRequestRecovery` |
| 4 | `uv run ruff check` passes | Yes | Clean |
| 5 | `uv run pytest` passes | Yes | 305 passed |

## Testing

- `uv run ruff check` — clean
- `uv run pytest` — all tests pass
