### PR TITLE
fix(tools): add member to decode_payload DEBUG log

### DIFF
--- a/src/pcap_agent/tools/decode_payload.py
+++ b/src/pcap_agent/tools/decode_payload.py
@@ -41,7 +41,9 @@ def decode_payload(
             "hint": "Provide a valid hex string.",
         }
 
-    logger.debug("decode_payload: format=%s, input=%d bytes", format, len(raw))
+    logger.debug(
+        "decode_payload: format=%s, input=%d bytes, member=%s", format, len(raw), member
+    )
 
     if format == "deflate":
         return _decompress_deflate(raw)

--- a/tests/test_decode_payload_tool.py
+++ b/tests/test_decode_payload_tool.py
@@ -247,3 +247,14 @@ class TestZipMemberNotFound:
 
         assert "error" in result
         assert result.get("hint") == "list members first"
+
+
+class TestDebugLogging:
+    def test_debug_log_includes_member(self, caplog):
+        import logging
+
+        compressed = gzip.compress(b"hello")
+        with caplog.at_level(logging.DEBUG, logger="pcap_agent.tools.decode_payload"):
+            decode_payload(compressed.hex(), member=0)
+
+        assert any("member=0" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Adds the `member` argument to the DEBUG log line in `decode_payload()` so log output includes all three call parameters: format, input byte count, and member.

Closes #74

## Changes

- Updated `decode_payload()` to include `member=%s` in the DEBUG log call
- Added `TestDebugLogging::test_debug_log_includes_member` to verify the log output

## Acceptance Criteria Coverage

| # | Criterion | Covered | Evidence |
|---|-----------|---------|----------|
| 1 | DEBUG log includes `member` argument | Yes | `tests/test_decode_payload_tool.py::TestDebugLogging::test_debug_log_includes_member` |
| 2 | `uv run ruff check` passes | Yes | All checks passed |
| 3 | `uv run pytest` passes | Yes | 306 passed |

## Testing

- `uv run ruff check` — clean
- `uv run pytest` — all tests pass
